### PR TITLE
Add initial test coverage for ConnectionService

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation(kotlin("test"))
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
 }
 
 kotlin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,12 +10,6 @@ plugins {
 group = "at.aau.se2"
 version = "0.0.1-SNAPSHOT"
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(21))
-    }
-}
-
 repositories {
     mavenCentral()
 }
@@ -25,7 +19,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-websocket")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation(kotlin("test"))
 }
 
 kotlin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.java.home=C:\\Program Files\\Eclipse Adoptium\\jdk-21.0.6.7-hotspot
+org.gradle.java.installations.auto-detect=false

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/GameControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/GameControllerTest.kt
@@ -1,0 +1,79 @@
+package at.aau.se2.skyjo.controller
+
+import at.aau.se2.skyjo.model.MessageType
+import at.aau.se2.skyjo.model.PlayerMessage
+import at.aau.se2.skyjo.service.ConnectionService
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor
+
+class GameControllerTest {
+
+    private val connectionService: ConnectionService = mock()
+    private val controller = GameController(connectionService)
+
+    @Test
+    fun `joinGame registers player and returns PLAYER_JOINED`() {
+        val headerAccessor = SimpMessageHeaderAccessor.create()
+        headerAccessor.sessionId = "s1"
+
+        val message = PlayerMessage("Alice")
+
+        val result = controller.joinGame(message, headerAccessor)
+
+        verify(connectionService).registerSession("s1", "Alice")
+        assertEquals(MessageType.PLAYER_JOINED, result.type)
+        assertEquals("Alice joined.", result.content)
+        assertEquals("Alice", result.playerName)
+    }
+
+    @Test
+    fun `joinGame returns ERROR if sessionId is null`() {
+        val headerAccessor = SimpMessageHeaderAccessor.create()
+        val message = PlayerMessage("Alice")
+
+        val result = controller.joinGame(message, headerAccessor)
+
+        assertEquals(MessageType.ERROR, result.type)
+    }
+
+    @Test
+    fun `leaveGame removes session and returns PLAYER_LEFT`() {
+        val headerAccessor = SimpMessageHeaderAccessor.create()
+        headerAccessor.sessionId = "s1"
+
+        org.mockito.kotlin.whenever(connectionService.removeSession("s1"))
+            .thenReturn("Alice")
+
+        val result = controller.leaveGame(headerAccessor)
+
+        verify(connectionService).removeSession("s1")
+        assertEquals(MessageType.PLAYER_LEFT, result.type)
+        assertEquals("Alice left.", result.content)
+        assertEquals("Alice", result.playerName)
+    }
+    @Test
+    fun `leaveGame returns Unknown when session is not found`() {
+        val headerAccessor = SimpMessageHeaderAccessor.create()
+        headerAccessor.sessionId = "s1"
+
+        org.mockito.kotlin.whenever(connectionService.removeSession("s1"))
+            .thenReturn(null)
+
+        val result = controller.leaveGame(headerAccessor)
+
+        assertEquals(MessageType.PLAYER_LEFT, result.type)
+        assertEquals("Unknown left.", result.content)
+        assertNull(result.playerName)
+    }
+    @Test
+    fun `leaveGame returns ERROR if sessionId is null`() {
+        val headerAccessor = SimpMessageHeaderAccessor.create()
+
+        val result = controller.leaveGame(headerAccessor)
+
+        assertEquals(MessageType.ERROR, result.type)
+    }
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/service/ConnectionServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/ConnectionServiceTest.kt
@@ -1,0 +1,35 @@
+package at.aau.se2.skyjo.service
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class ConnectionServiceTest {
+
+    private val service = ConnectionService()
+
+    @Test
+    fun `registerSession stores player and marks session as connected`() {
+        service.registerSession("s1", "Alice")
+
+        assertEquals("Alice", service.getPlayerName("s1"))
+        assertTrue(service.isConnected("s1"))
+        assertEquals(1, service.getConnectedCount())
+    }
+
+    @Test
+    fun `removeSession removes and returns player`() {
+        service.registerSession("s1", "Alice")
+
+        val removed = service.removeSession("s1")
+
+        assertEquals("Alice", removed)
+        assertNull(service.getPlayerName("s1"))
+        assertFalse(service.isConnected("s1"))
+        assertEquals(0, service.getConnectedCount())
+    }
+
+    @Test
+    fun `removeSession returns null for unknown session`() {
+        assertNull(service.removeSession("unknown"))
+    }
+}


### PR DESCRIPTION
added initial test coverage for ConnectionService. Covers registerSession, removeSession and edge cases. Let me know if I should add more tests