### PR TITLE
feat: implement Kartentausch Mitspieler (PlayerSwap) action card

### DIFF
--- a/src/main/kotlin/at/aau/se2/skyjo/game/model/ActionCardEffect.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/game/model/ActionCardEffect.kt
@@ -1,14 +1,61 @@
 package at.aau.se2.skyjo.game.model
 
+import at.aau.se2.skyjo.game.error.InvalidMoveException
+
 sealed interface ActionCardEffect {
     fun apply(state: GameState, parameters: ActionCardParameters): GameState
 
     data object Placeholder : ActionCardEffect {
         override fun apply(state: GameState, parameters: ActionCardParameters): GameState = state
     }
+
+    data object PlayerSwap : ActionCardEffect {
+        override fun apply(state: GameState, parameters: ActionCardParameters): GameState {
+            require(parameters is ActionCardParameters.PlayerSwap) {
+                "PlayerSwap effect requires PlayerSwap parameters"
+            }
+
+            if (parameters.player1Id == parameters.player2Id) {
+                throw InvalidMoveException("cannot swap cards between the same player")
+            }
+
+            val p1 = state.players.find { it.id == parameters.player1Id }
+                ?: throw InvalidMoveException("player ${parameters.player1Id} not found")
+            val p2 = state.players.find { it.id == parameters.player2Id }
+                ?: throw InvalidMoveException("player ${parameters.player2Id} not found")
+
+            val slot1 = p1.board.slotAt(parameters.player1Position)
+            if (slot1 !is BoardSlot.Occupied) {
+                throw InvalidMoveException("slot ${parameters.player1Position} of player ${parameters.player1Id} is not occupied")
+            }
+
+            val slot2 = p2.board.slotAt(parameters.player2Position)
+            if (slot2 !is BoardSlot.Occupied) {
+                throw InvalidMoveException("slot ${parameters.player2Position} of player ${parameters.player2Id} is not occupied")
+            }
+
+            val updatedP1Board = p1.board.copy(
+                slots = p1.board.slots + (parameters.player1Position to slot1.copy(card = slot2.card))
+            )
+            val updatedP2Board = p2.board.copy(
+                slots = p2.board.slots + (parameters.player2Position to slot2.copy(card = slot1.card))
+            )
+
+            val updatedPlayers = state.players.map { player ->
+                when (player.id) {
+                    parameters.player1Id -> player.copy(board = updatedP1Board)
+                    parameters.player2Id -> player.copy(board = updatedP2Board)
+                    else -> player
+                }
+            }
+
+            return state.copy(players = updatedPlayers)
+        }
+    }
 }
 
 fun SkyjoCard.ActionCard.toEffect(): ActionCardEffect =
     when (this) {
         is SkyjoCard.ActionCard.Placeholder -> ActionCardEffect.Placeholder
+        is SkyjoCard.ActionCard.PlayerSwapCard -> ActionCardEffect.PlayerSwap
     }

--- a/src/main/kotlin/at/aau/se2/skyjo/game/model/PlayActionCardCommand.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/game/model/PlayActionCardCommand.kt
@@ -7,4 +7,11 @@ data class PlayActionCardCommand(
 
 sealed interface ActionCardParameters {
     data object None : ActionCardParameters
+
+    data class PlayerSwap(
+        val player1Id: String,
+        val player1Position: BoardPosition,
+        val player2Id: String,
+        val player2Position: BoardPosition,
+    ) : ActionCardParameters
 }

--- a/src/main/kotlin/at/aau/se2/skyjo/game/model/SkyjoCard.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/game/model/SkyjoCard.kt
@@ -14,6 +14,10 @@ sealed interface SkyjoCard {
         data class Placeholder(
             override val id: Int,
         ) : ActionCard
+
+        data class PlayerSwapCard(
+            override val id: Int,
+        ) : ActionCard
     }
 }
 
@@ -30,4 +34,5 @@ fun SkyjoCard.displayLabel(): String =
     when (this) {
         is SkyjoCard.NumberCard -> value.toString()
         is SkyjoCard.ActionCard.Placeholder -> "Action"
+        is SkyjoCard.ActionCard.PlayerSwapCard -> "Swap"
     }

--- a/src/main/kotlin/at/aau/se2/skyjo/game/model/SkyjoDeckFactory.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/game/model/SkyjoDeckFactory.kt
@@ -28,7 +28,7 @@ object SkyjoDeckFactory {
         val random = seed?.let { Random(it + 1L) } ?: Random.Default
         val numberCardCount = cardDistribution.size
         val actionCards = List(ACTION_CARD_COUNT) { index ->
-            SkyjoCard.ActionCard.Placeholder(id = numberCardCount + index + 1)
+            SkyjoCard.ActionCard.PlayerSwapCard(id = numberCardCount + index + 1)
         }.shuffled(random)
         return ActionDrawPile(actionCards)
     }

--- a/src/main/kotlin/at/aau/se2/skyjo/game/model/SkyjoDeckFactory.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/game/model/SkyjoDeckFactory.kt
@@ -13,6 +13,7 @@ object SkyjoDeckFactory {
     }
 
     private const val ACTION_CARD_COUNT = 21
+    private const val PLAYER_SWAP_CARD_COUNT = 3
 
     fun createShuffledDrawPile(seed: Long? = null): DrawPile {
         val random = seed?.let { Random(it) } ?: Random.Default
@@ -28,7 +29,9 @@ object SkyjoDeckFactory {
         val random = seed?.let { Random(it + 1L) } ?: Random.Default
         val numberCardCount = cardDistribution.size
         val actionCards = List(ACTION_CARD_COUNT) { index ->
-            SkyjoCard.ActionCard.PlayerSwapCard(id = numberCardCount + index + 1)
+            val id = numberCardCount + index + 1
+            if (index < PLAYER_SWAP_CARD_COUNT) SkyjoCard.ActionCard.PlayerSwapCard(id = id)
+            else SkyjoCard.ActionCard.Placeholder(id = id)
         }.shuffled(random)
         return ActionDrawPile(actionCards)
     }

--- a/src/main/kotlin/at/aau/se2/skyjo/model/GameActionMessage.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/model/GameActionMessage.kt
@@ -7,10 +7,19 @@ data class GameActionMessage(
     val source: DrawSource? = null,
     val row: Int? = null,
     val col: Int? = null,
+    val actionCardIndex: Int? = null,
+    val targetPlayer1Id: String? = null,
+    val targetPlayer1Row: Int? = null,
+    val targetPlayer1Col: Int? = null,
+    val targetPlayer2Id: String? = null,
+    val targetPlayer2Row: Int? = null,
+    val targetPlayer2Col: Int? = null,
 )
 
 enum class ActionType {
     DRAW,
     REPLACE,
     DISCARD_AND_REVEAL,
+    PLAY_ACTION_CARD,
+    DISCARD_ACTION_CARD,
 }

--- a/src/main/kotlin/at/aau/se2/skyjo/model/GameUpdateMessage.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/model/GameUpdateMessage.kt
@@ -21,6 +21,7 @@ data class PlayerBoardDto(
     val playerId: String,
     val nickname: String,
     val board: List<List<BoardSlotDto>>,
+    val actionCardTypes: List<String> = emptyList(),
 )
 
 data class BoardSlotDto(

--- a/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
@@ -1,11 +1,13 @@
 package at.aau.se2.skyjo.service
 
+import at.aau.se2.skyjo.game.model.ActionCardParameters
 import at.aau.se2.skyjo.game.model.BoardLayout
 import at.aau.se2.skyjo.game.model.BoardPosition
 import at.aau.se2.skyjo.game.model.BoardSlot
 import at.aau.se2.skyjo.game.model.DrawSource
 import at.aau.se2.skyjo.game.model.GamePhase
 import at.aau.se2.skyjo.game.model.GameState
+import at.aau.se2.skyjo.game.model.PlayActionCardCommand
 import at.aau.se2.skyjo.game.model.SkyjoCard
 import at.aau.se2.skyjo.game.model.scoreValue
 import at.aau.se2.skyjo.game.service.SkyjoEngine
@@ -107,6 +109,40 @@ class GameService(
                 val row = action.row ?: error("row required for DISCARD_AND_REVEAL action")
                 val col = action.col ?: error("col required for DISCARD_AND_REVEAL action")
                 engine.discardDrawnCardAndReveal(state, BoardPosition(row, col))
+            }
+            ActionType.PLAY_ACTION_CARD -> {
+                val cardIndex = action.actionCardIndex
+                    ?: error("actionCardIndex required for PLAY_ACTION_CARD")
+                val p1Id = action.targetPlayer1Id
+                    ?: error("targetPlayer1Id required for PLAY_ACTION_CARD")
+                val p1Row = action.targetPlayer1Row
+                    ?: error("targetPlayer1Row required for PLAY_ACTION_CARD")
+                val p1Col = action.targetPlayer1Col
+                    ?: error("targetPlayer1Col required for PLAY_ACTION_CARD")
+                val p2Id = action.targetPlayer2Id
+                    ?: error("targetPlayer2Id required for PLAY_ACTION_CARD")
+                val p2Row = action.targetPlayer2Row
+                    ?: error("targetPlayer2Row required for PLAY_ACTION_CARD")
+                val p2Col = action.targetPlayer2Col
+                    ?: error("targetPlayer2Col required for PLAY_ACTION_CARD")
+
+                engine.playActionCard(
+                    state,
+                    PlayActionCardCommand(
+                        actionCardIndex = cardIndex,
+                        parameters = ActionCardParameters.PlayerSwap(
+                            player1Id = p1Id,
+                            player1Position = BoardPosition(p1Row, p1Col),
+                            player2Id = p2Id,
+                            player2Position = BoardPosition(p2Row, p2Col),
+                        ),
+                    ),
+                )
+            }
+            ActionType.DISCARD_ACTION_CARD -> {
+                val cardIndex = action.actionCardIndex
+                    ?: error("actionCardIndex required for DISCARD_ACTION_CARD")
+                engine.discardActionCard(state, cardIndex)
             }
         }
 

--- a/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
@@ -165,6 +165,12 @@ class GameService(
                 playerId = playerState.id,
                 nickname = playerInfo[playerState.id] ?: playerState.id,
                 board = rows,
+                actionCardTypes = playerState.actionCards.map { card ->
+                    when (card) {
+                        is SkyjoCard.ActionCard.PlayerSwapCard -> "PLAYER_SWAP"
+                        is SkyjoCard.ActionCard.Placeholder -> "PLACEHOLDER"
+                    }
+                },
             )
         }
 

--- a/src/test/kotlin/at/aau/se2/skyjo/game/model/ActionCardEffectTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/game/model/ActionCardEffectTest.kt
@@ -1,20 +1,186 @@
 package at.aau.se2.skyjo.game.model
 
-import org.junit.jupiter.api.Assertions.assertSame
+import at.aau.se2.skyjo.game.error.InvalidMoveException
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class ActionCardEffectTest {
-    @Test
-    fun placeholderActionCardMapsToPlaceholderEffect(){
-        val card = SkyjoCard.ActionCard.Placeholder(id = 1)
 
+    // ── existing tests (keep as-is) ─────────────────────────────────────────
+
+    @Test
+    fun placeholderActionCardMapsToPlaceholderEffect() {
+        val card = SkyjoCard.ActionCard.Placeholder(id = 1)
         assertSame(ActionCardEffect.Placeholder, card.toEffect())
     }
 
     @Test
-    fun placeholderActionCardEffectKeepsStateUnchanged(){
+    fun placeholderActionCardEffectKeepsStateUnchanged() {
         val state = GameState()
-
         assertSame(state, ActionCardEffect.Placeholder.apply(state, ActionCardParameters.None))
+    }
+
+    // ── PlayerSwapCard mapping ───────────────────────────────────────────────
+
+    @Test
+    fun `PlayerSwapCard maps to PlayerSwap effect`() {
+        val card = SkyjoCard.ActionCard.PlayerSwapCard(id = 2)
+        assertSame(ActionCardEffect.PlayerSwap, card.toEffect())
+    }
+
+    // ── PlayerSwap effect ────────────────────────────────────────────────────
+
+    @Test
+    fun `PlayerSwap swaps cards between two players`() {
+        val card1 = SkyjoCard.NumberCard(id = 10, value = 3)
+        val card2 = SkyjoCard.NumberCard(id = 20, value = 7)
+        val pos1 = BoardPosition(0, 0)
+        val pos2 = BoardPosition(1, 1)
+
+        val board1 = buildBoard(mapOf(pos1 to BoardSlot.Occupied(card1, faceUp = true)))
+        val board2 = buildBoard(mapOf(pos2 to BoardSlot.Occupied(card2, faceUp = false)))
+
+        val state = GameState(
+            players = listOf(
+                PlayerState(id = "p1", board = board1),
+                PlayerState(id = "p2", board = board2),
+            )
+        )
+
+        val params = ActionCardParameters.PlayerSwap(
+            player1Id = "p1", player1Position = pos1,
+            player2Id = "p2", player2Position = pos2,
+        )
+
+        val result = ActionCardEffect.PlayerSwap.apply(state, params)
+
+        val p1Slot = result.players.find { it.id == "p1" }!!.board.slotAt(pos1) as BoardSlot.Occupied
+        val p2Slot = result.players.find { it.id == "p2" }!!.board.slotAt(pos2) as BoardSlot.Occupied
+
+        assertEquals(card2, p1Slot.card)   // p1 now has card2
+        assertEquals(card1, p2Slot.card)   // p2 now has card1
+        assertTrue(p1Slot.faceUp)          // face-up state preserved from original slot1
+        assertFalse(p2Slot.faceUp)         // face-up state preserved from original slot2
+    }
+
+    @Test
+    fun `PlayerSwap works with face-down cards`() {
+        val card1 = SkyjoCard.NumberCard(id = 10, value = 5)
+        val card2 = SkyjoCard.NumberCard(id = 20, value = 9)
+        val pos = BoardPosition(2, 3)
+
+        val board1 = buildBoard(mapOf(pos to BoardSlot.Occupied(card1, faceUp = false)))
+        val board2 = buildBoard(mapOf(pos to BoardSlot.Occupied(card2, faceUp = false)))
+
+        val state = GameState(
+            players = listOf(
+                PlayerState(id = "p1", board = board1),
+                PlayerState(id = "p2", board = board2),
+            )
+        )
+
+        val params = ActionCardParameters.PlayerSwap("p1", pos, "p2", pos)
+        val result = ActionCardEffect.PlayerSwap.apply(state, params)
+
+        val p1Slot = result.players.find { it.id == "p1" }!!.board.slotAt(pos) as BoardSlot.Occupied
+        val p2Slot = result.players.find { it.id == "p2" }!!.board.slotAt(pos) as BoardSlot.Occupied
+
+        assertEquals(card2, p1Slot.card)
+        assertEquals(card1, p2Slot.card)
+    }
+
+    @Test
+    fun `PlayerSwap throws when both player IDs are the same`() {
+        val pos = BoardPosition(0, 0)
+        val board = buildBoard(mapOf(pos to BoardSlot.Occupied(SkyjoCard.NumberCard(1, 1), faceUp = true)))
+        val state = GameState(players = listOf(PlayerState(id = "p1", board = board)))
+
+        val params = ActionCardParameters.PlayerSwap("p1", pos, "p1", BoardPosition(0, 1))
+
+        assertThrows<InvalidMoveException> {
+            ActionCardEffect.PlayerSwap.apply(state, params)
+        }
+    }
+
+    @Test
+    fun `PlayerSwap throws when player1 not found`() {
+        val pos = BoardPosition(0, 0)
+        val board = buildBoard(mapOf(pos to BoardSlot.Occupied(SkyjoCard.NumberCard(1, 1), faceUp = true)))
+        val state = GameState(players = listOf(PlayerState(id = "p2", board = board)))
+
+        val params = ActionCardParameters.PlayerSwap("p1", pos, "p2", pos)
+
+        assertThrows<InvalidMoveException> {
+            ActionCardEffect.PlayerSwap.apply(state, params)
+        }
+    }
+
+    @Test
+    fun `PlayerSwap throws when player2 not found`() {
+        val pos = BoardPosition(0, 0)
+        val board = buildBoard(mapOf(pos to BoardSlot.Occupied(SkyjoCard.NumberCard(1, 1), faceUp = true)))
+        val state = GameState(players = listOf(PlayerState(id = "p1", board = board)))
+
+        val params = ActionCardParameters.PlayerSwap("p1", pos, "p2", pos)
+
+        assertThrows<InvalidMoveException> {
+            ActionCardEffect.PlayerSwap.apply(state, params)
+        }
+    }
+
+    @Test
+    fun `PlayerSwap throws when slot1 is cleared`() {
+        val pos1 = BoardPosition(0, 0)
+        val pos2 = BoardPosition(0, 1)
+        val board1 = buildBoard(mapOf(pos1 to BoardSlot.Cleared))
+        val board2 = buildBoard(mapOf(pos2 to BoardSlot.Occupied(SkyjoCard.NumberCard(1, 5), faceUp = true)))
+
+        val state = GameState(
+            players = listOf(
+                PlayerState(id = "p1", board = board1),
+                PlayerState(id = "p2", board = board2),
+            )
+        )
+
+        assertThrows<InvalidMoveException> {
+            ActionCardEffect.PlayerSwap.apply(state, ActionCardParameters.PlayerSwap("p1", pos1, "p2", pos2))
+        }
+    }
+
+    @Test
+    fun `PlayerSwap throws when slot2 is cleared`() {
+        val pos1 = BoardPosition(0, 0)
+        val pos2 = BoardPosition(0, 1)
+        val board1 = buildBoard(mapOf(pos1 to BoardSlot.Occupied(SkyjoCard.NumberCard(1, 5), faceUp = true)))
+        val board2 = buildBoard(mapOf(pos2 to BoardSlot.Cleared))
+
+        val state = GameState(
+            players = listOf(
+                PlayerState(id = "p1", board = board1),
+                PlayerState(id = "p2", board = board2),
+            )
+        )
+
+        assertThrows<InvalidMoveException> {
+            ActionCardEffect.PlayerSwap.apply(state, ActionCardParameters.PlayerSwap("p1", pos1, "p2", pos2))
+        }
+    }
+
+    // ── helper ───────────────────────────────────────────────────────────────
+
+    /**
+     * Builds a full 3×4 PlayerBoard. Positions listed in [overrides] use the
+     * provided slot; all others get a default face-down NumberCard.
+     */
+    private fun buildBoard(overrides: Map<BoardPosition, BoardSlot> = emptyMap()): PlayerBoard {
+        var idCounter = 1
+        val slots = BoardLayout.POSITIONS.associateWith { pos ->
+            overrides[pos] ?: BoardSlot.Occupied(
+                card = SkyjoCard.NumberCard(id = idCounter++, value = 0),
+                faceUp = false,
+            )
+        }
+        return PlayerBoard(slots)
     }
 }

--- a/src/test/kotlin/at/aau/se2/skyjo/game/model/ActionCardEffectTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/game/model/ActionCardEffectTest.kt
@@ -94,6 +94,122 @@ class ActionCardEffectTest {
         }
     }
 
+    @Test
+    fun playerSwapActionCardEffectRejectsMissingParameters() {
+        assertThrows(IllegalArgumentException::class.java) {
+            ActionCardEffect.PlayerSwap.apply(GameState(), ActionCardParameters.None)
+        }
+    }
+
+    @Test
+    fun playerSwapActionCardEffectRejectsUnknownFirstPlayer() {
+        val pos = BoardPosition(0, 0)
+        val state = GameState(
+            players = listOf(
+                PlayerState(
+                    id = "p2",
+                    board = buildBoard(mapOf(pos to BoardSlot.Occupied(SkyjoCard.NumberCard(1, 1), faceUp = true))),
+                ),
+            ),
+        )
+
+        val exception = assertThrows(InvalidMoveException::class.java) {
+            ActionCardEffect.PlayerSwap.apply(
+                state,
+                ActionCardParameters.PlayerSwap("p1", pos, "p2", pos),
+            )
+        }
+
+        assertTrue(exception.message!!.contains("player p1 not found"))
+    }
+
+    @Test
+    fun playerSwapActionCardEffectRejectsUnknownSecondPlayer() {
+        val pos = BoardPosition(0, 0)
+        val state = GameState(
+            players = listOf(
+                PlayerState(
+                    id = "p1",
+                    board = buildBoard(mapOf(pos to BoardSlot.Occupied(SkyjoCard.NumberCard(1, 1), faceUp = true))),
+                ),
+            ),
+        )
+
+        val exception = assertThrows(InvalidMoveException::class.java) {
+            ActionCardEffect.PlayerSwap.apply(
+                state,
+                ActionCardParameters.PlayerSwap("p1", pos, "p2", pos),
+            )
+        }
+
+        assertTrue(exception.message!!.contains("player p2 not found"))
+    }
+
+    @Test
+    fun playerSwapActionCardEffectRejectsClearedFirstSlot() {
+        val pos1 = BoardPosition(0, 0)
+        val pos2 = BoardPosition(0, 1)
+        val state = GameState(
+            players = listOf(
+                PlayerState(id = "p1", board = buildBoard(mapOf(pos1 to BoardSlot.Cleared))),
+                PlayerState(id = "p2", board = buildBoard(mapOf(pos2 to BoardSlot.Occupied(SkyjoCard.NumberCard(2, 2), faceUp = true)))),
+            ),
+        )
+
+        val exception = assertThrows(InvalidMoveException::class.java) {
+            ActionCardEffect.PlayerSwap.apply(
+                state,
+                ActionCardParameters.PlayerSwap("p1", pos1, "p2", pos2),
+            )
+        }
+
+        assertTrue(exception.message!!.contains("slot $pos1 of player p1 is not occupied"))
+    }
+
+    @Test
+    fun playerSwapActionCardEffectRejectsClearedSecondSlot() {
+        val pos1 = BoardPosition(0, 0)
+        val pos2 = BoardPosition(0, 1)
+        val state = GameState(
+            players = listOf(
+                PlayerState(id = "p1", board = buildBoard(mapOf(pos1 to BoardSlot.Occupied(SkyjoCard.NumberCard(1, 1), faceUp = true)))),
+                PlayerState(id = "p2", board = buildBoard(mapOf(pos2 to BoardSlot.Cleared))),
+            ),
+        )
+
+        val exception = assertThrows(InvalidMoveException::class.java) {
+            ActionCardEffect.PlayerSwap.apply(
+                state,
+                ActionCardParameters.PlayerSwap("p1", pos1, "p2", pos2),
+            )
+        }
+
+        assertTrue(exception.message!!.contains("slot $pos2 of player p2 is not occupied"))
+    }
+
+    @Test
+    fun playerSwapActionCardEffectLeavesOtherPlayersUnchanged() {
+        val card1 = SkyjoCard.NumberCard(id = 10, value = 3)
+        val card2 = SkyjoCard.NumberCard(id = 20, value = 7)
+        val otherBoard = buildBoard()
+        val pos1 = BoardPosition(0, 0)
+        val pos2 = BoardPosition(1, 1)
+        val state = GameState(
+            players = listOf(
+                PlayerState(id = "p1", board = buildBoard(mapOf(pos1 to BoardSlot.Occupied(card1, faceUp = true)))),
+                PlayerState(id = "p2", board = buildBoard(mapOf(pos2 to BoardSlot.Occupied(card2, faceUp = false)))),
+                PlayerState(id = "p3", board = otherBoard),
+            ),
+        )
+
+        val result = ActionCardEffect.PlayerSwap.apply(
+            state,
+            ActionCardParameters.PlayerSwap("p1", pos1, "p2", pos2),
+        )
+
+        assertSame(otherBoard, result.players.first { it.id == "p3" }.board)
+    }
+
     private fun buildBoard(overrides: Map<BoardPosition, BoardSlot> = emptyMap()): PlayerBoard {
         var idCounter = 1
         val slots = BoardLayout.POSITIONS.associateWith { pos ->

--- a/src/test/kotlin/at/aau/se2/skyjo/game/model/SkyjoCardTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/game/model/SkyjoCardTest.kt
@@ -31,4 +31,16 @@ class SkyjoCardTest {
 
         assertEquals("Action", card.displayLabel())
     }
+
+    @Test
+    fun `PlayerSwapCard scoreValue is ACTION_CARD_SCORE`() {
+        val card = SkyjoCard.ActionCard.PlayerSwapCard(id = 99)
+        assertEquals(ACTION_CARD_SCORE, card.scoreValue())
+    }
+
+    @Test
+    fun `PlayerSwapCard displayLabel is Swap`() {
+        val card = SkyjoCard.ActionCard.PlayerSwapCard(id = 99)
+        assertEquals("Swap", card.displayLabel())
+    }
 }

--- a/src/test/kotlin/at/aau/se2/skyjo/game/model/SkyjoDeckFactoryTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/game/model/SkyjoDeckFactoryTest.kt
@@ -82,7 +82,7 @@ class SkyjoDeckFactoryTest {
     }
 
     @Test
-    fun `action draw pile contains only PlayerSwapCards`() {
+    fun `action draw pile has gated PlayerSwap cards and Placeholders`() {
         val actionPile = SkyjoDeckFactory.createShuffledActionDrawPile(seed = 1L)
         var remaining = actionPile
         val allCards = buildList {
@@ -92,7 +92,9 @@ class SkyjoDeckFactoryTest {
                 remaining = result.remainingPile
             }
         }
-        assertTrue(allCards.all { it is SkyjoCard.ActionCard.PlayerSwapCard })
         assertEquals(21, allCards.size)
+        assertEquals(3, allCards.count { it is SkyjoCard.ActionCard.PlayerSwapCard })
+        assertEquals(18, allCards.count { it is SkyjoCard.ActionCard.Placeholder })
+        assertTrue(allCards.all { it is SkyjoCard.ActionCard })
     }
 }

--- a/src/test/kotlin/at/aau/se2/skyjo/game/model/SkyjoDeckFactoryTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/game/model/SkyjoDeckFactoryTest.kt
@@ -80,4 +80,19 @@ class SkyjoDeckFactoryTest {
 
         assertNotEquals(pile1.cards, pile2.cards)
     }
+
+    @Test
+    fun `action draw pile contains only PlayerSwapCards`() {
+        val actionPile = SkyjoDeckFactory.createShuffledActionDrawPile(seed = 1L)
+        var remaining = actionPile
+        val allCards = buildList {
+            while (remaining.size > 0) {
+                val result = remaining.draw()
+                add(result.card)
+                remaining = result.remainingPile
+            }
+        }
+        assertTrue(allCards.all { it is SkyjoCard.ActionCard.PlayerSwapCard })
+        assertEquals(21, allCards.size)
+    }
 }

--- a/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
@@ -281,6 +281,124 @@ class GameServiceTest {
 
         assertNotNull(service.getCurrentState())
     }
+
+    // ── DISCARD_ACTION_CARD ───────────────────────────────────────────────────
+
+    @Test
+    fun `processAction DISCARD_ACTION_CARD throws when actionCardIndex is missing`() {
+        service.startGame(players)
+        val currentPlayerId = service.getCurrentState()!!.currentPlayerId!!
+
+        // Give current player an action card by drawing from the action deck
+        service.processAction(
+            currentPlayerId,
+            GameActionMessage(ActionType.DRAW, source = DrawSource.ACTION_DECK)
+        )
+
+        // Re-create to test missing index error directly
+        val s3 = GameService(SkyjoEngine(), null)
+        s3.startGame(players)
+        val pid3 = s3.getCurrentState()!!.currentPlayerId!!
+        s3.processAction(pid3, GameActionMessage(ActionType.DRAW, source = DrawSource.ACTION_DECK))
+
+        val nextPid = s3.getCurrentState()!!.currentPlayerId!!
+        val ex = assertThrows<IllegalStateException> {
+            s3.processAction(nextPid, GameActionMessage(ActionType.DISCARD_ACTION_CARD))
+        }
+        assertTrue(ex.message!!.contains("actionCardIndex required"))
+    }
+
+    @Test
+    fun `processAction DISCARD_ACTION_CARD removes card from player hand and advances turn`() {
+        service.startGame(players)
+        val currentPlayerId = service.getCurrentState()!!.currentPlayerId!!
+
+        // Draw an action card (this advances turn)
+        service.processAction(
+            currentPlayerId,
+            GameActionMessage(ActionType.DRAW, source = DrawSource.ACTION_DECK)
+        )
+
+        // Now the other player's turn — draw action card for them too
+        val otherPlayerId = service.getCurrentState()!!.currentPlayerId!!
+        service.processAction(
+            otherPlayerId,
+            GameActionMessage(ActionType.DRAW, source = DrawSource.ACTION_DECK)
+        )
+
+        // Back to first player — they have an action card; discard it
+        val pid = service.getCurrentState()!!.currentPlayerId!!
+        val stateBefore = service.getCurrentState()!!
+        val playerBefore = stateBefore.players.find { it.playerId == pid }!!
+        assertEquals(1, playerBefore.actionCardTypes.size)
+
+        val result = service.processAction(
+            pid,
+            GameActionMessage(ActionType.DISCARD_ACTION_CARD, actionCardIndex = 0)
+        )
+
+        val playerAfter = result.players.find { it.playerId == pid }!!
+        assertEquals(0, playerAfter.actionCardTypes.size)
+    }
+
+    // ── PLAY_ACTION_CARD ─────────────────────────────────────────────────────
+
+    @Test
+    fun `processAction PLAY_ACTION_CARD throws when actionCardIndex is missing`() {
+        service.startGame(players)
+        val currentPlayerId = service.getCurrentState()!!.currentPlayerId!!
+        service.processAction(currentPlayerId, GameActionMessage(ActionType.DRAW, source = DrawSource.ACTION_DECK))
+
+        val nextPid = service.getCurrentState()!!.currentPlayerId!!
+        service.processAction(nextPid, GameActionMessage(ActionType.DRAW, source = DrawSource.ACTION_DECK))
+
+        val pid = service.getCurrentState()!!.currentPlayerId!!
+        val ex = assertThrows<IllegalStateException> {
+            service.processAction(pid, GameActionMessage(ActionType.PLAY_ACTION_CARD))
+        }
+        assertTrue(ex.message!!.contains("actionCardIndex required"))
+    }
+
+    @Test
+    fun `processAction PLAY_ACTION_CARD performs swap and advances turn`() {
+        service.startGame(players)
+
+        // Let first player draw an action card
+        val pid1 = service.getCurrentState()!!.currentPlayerId!!
+        service.processAction(pid1, GameActionMessage(ActionType.DRAW, source = DrawSource.ACTION_DECK))
+
+        // Let second player draw an action card so we return to pid1
+        val pid2 = service.getCurrentState()!!.currentPlayerId!!
+        service.processAction(pid2, GameActionMessage(ActionType.DRAW, source = DrawSource.ACTION_DECK))
+
+        // pid1's turn — play the PlayerSwap action card
+        val pid = service.getCurrentState()!!.currentPlayerId!!
+        val stateBeforePlay = service.getCurrentState()!!
+
+        // Pick positions — we just need two different players and their (0,0) positions
+        val p1 = stateBeforePlay.players.find { it.playerId == pid }!!
+        val p2 = stateBeforePlay.players.find { it.playerId != pid }!!
+
+        val result = service.processAction(
+            pid,
+            GameActionMessage(
+                type = ActionType.PLAY_ACTION_CARD,
+                actionCardIndex = 0,
+                targetPlayer1Id = p1.playerId,
+                targetPlayer1Row = 0,
+                targetPlayer1Col = 0,
+                targetPlayer2Id = p2.playerId,
+                targetPlayer2Row = 0,
+                targetPlayer2Col = 0,
+            )
+        )
+
+        // Turn must have advanced
+        assertNotEquals(pid, result.currentPlayerId)
+        // The player who played the card should now have 0 action cards
+        val playerAfter = result.players.find { it.playerId == pid }!!
+        assertEquals(0, playerAfter.actionCardTypes.size)
+    }
 }
 
 // Helpers to access internal state for test setup

--- a/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
@@ -154,6 +154,18 @@ class GameServiceTest {
     }
 
     @Test
+    fun `processAction PLAY_ACTION_CARD throws when index is missing`() {
+        service.startGame(players)
+        val currentPlayerId = service.getCurrentState()!!.currentPlayerId!!
+
+        val exception = assertThrows<IllegalStateException> {
+            service.processAction(currentPlayerId, GameActionMessage(ActionType.PLAY_ACTION_CARD))
+        }
+
+        assertTrue(exception.message!!.contains("actionCardIndex required"))
+    }
+
+    @Test
     fun `processAction DRAW_VISIBLE_ACTION_CARD throws when index is missing`() {
         service.startGame(players)
         val currentPlayerId = service.getCurrentState()!!.currentPlayerId!!
@@ -349,6 +361,133 @@ class GameServiceTest {
         assertNotEquals(currentPlayerId, result.currentPlayerId)
         assertTrue(result.players.first { it.playerId == currentPlayerId }.actionCards.isEmpty())
     }
+
+    @Test
+    fun `processAction PLAY_ACTION_CARD rejects unavailable action card index`() {
+        service.startGame(players)
+        val state = getInternalGameState(service)
+        val currentPlayerId = state.currentPlayerId!!
+        val updatedPlayers = state.players.mapIndexed { index, player ->
+            if (index == state.currentPlayerIndex) {
+                player.copy(actionCards = listOf(SkyjoCard.ActionCard.PlayerSwapCard(id = 1000)))
+            } else {
+                player
+            }
+        }
+        setInternalGameState(service, state.copy(players = updatedPlayers))
+
+        val exception = assertThrows<IllegalStateException> {
+            service.processAction(
+                currentPlayerId,
+                GameActionMessage(ActionType.PLAY_ACTION_CARD, actionCardIndex = 3),
+            )
+        }
+
+        assertTrue(exception.message!!.contains("action card index 3 is not available"))
+    }
+
+    @Test
+    fun `processAction PLAY_ACTION_CARD with placeholder uses no parameters`() {
+        service.startGame(players)
+        val state = getInternalGameState(service)
+        val currentPlayerId = state.currentPlayerId!!
+        val updatedPlayers = state.players.mapIndexed { index, player ->
+            if (index == state.currentPlayerIndex) {
+                player.copy(actionCards = listOf(SkyjoCard.ActionCard.Placeholder(id = 1000)))
+            } else {
+                player
+            }
+        }
+        setInternalGameState(service, state.copy(players = updatedPlayers))
+
+        val result = service.processAction(
+            currentPlayerId,
+            GameActionMessage(ActionType.PLAY_ACTION_CARD, actionCardIndex = 0),
+        )
+
+        assertNotEquals(currentPlayerId, result.currentPlayerId)
+        assertTrue(result.players.first { it.playerId == currentPlayerId }.actionCards.isEmpty())
+    }
+
+    @Test
+    fun `processAction PLAY_ACTION_CARD player swap requires first player id`() {
+        assertPlayerSwapMissingFieldFails(
+            action = validPlayerSwapAction().copy(targetPlayer1Id = null),
+            expectedMessage = "targetPlayer1Id required",
+        )
+    }
+
+    @Test
+    fun `processAction PLAY_ACTION_CARD player swap requires first player row`() {
+        assertPlayerSwapMissingFieldFails(
+            action = validPlayerSwapAction().copy(targetPlayer1Row = null),
+            expectedMessage = "targetPlayer1Row required",
+        )
+    }
+
+    @Test
+    fun `processAction PLAY_ACTION_CARD player swap requires first player col`() {
+        assertPlayerSwapMissingFieldFails(
+            action = validPlayerSwapAction().copy(targetPlayer1Col = null),
+            expectedMessage = "targetPlayer1Col required",
+        )
+    }
+
+    @Test
+    fun `processAction PLAY_ACTION_CARD player swap requires second player id`() {
+        assertPlayerSwapMissingFieldFails(
+            action = validPlayerSwapAction().copy(targetPlayer2Id = null),
+            expectedMessage = "targetPlayer2Id required",
+        )
+    }
+
+    @Test
+    fun `processAction PLAY_ACTION_CARD player swap requires second player row`() {
+        assertPlayerSwapMissingFieldFails(
+            action = validPlayerSwapAction().copy(targetPlayer2Row = null),
+            expectedMessage = "targetPlayer2Row required",
+        )
+    }
+
+    @Test
+    fun `processAction PLAY_ACTION_CARD player swap requires second player col`() {
+        assertPlayerSwapMissingFieldFails(
+            action = validPlayerSwapAction().copy(targetPlayer2Col = null),
+            expectedMessage = "targetPlayer2Col required",
+        )
+    }
+
+    private fun assertPlayerSwapMissingFieldFails(action: GameActionMessage, expectedMessage: String) {
+        service.startGame(players)
+        val state = getInternalGameState(service)
+        val currentPlayerId = state.currentPlayerId!!
+        val updatedPlayers = state.players.mapIndexed { index, player ->
+            if (index == state.currentPlayerIndex) {
+                player.copy(actionCards = listOf(SkyjoCard.ActionCard.PlayerSwapCard(id = 1000)))
+            } else {
+                player
+            }
+        }
+        setInternalGameState(service, state.copy(players = updatedPlayers))
+
+        val exception = assertThrows<IllegalStateException> {
+            service.processAction(currentPlayerId, action)
+        }
+
+        assertTrue(exception.message!!.contains(expectedMessage))
+    }
+
+    private fun validPlayerSwapAction(): GameActionMessage =
+        GameActionMessage(
+            type = ActionType.PLAY_ACTION_CARD,
+            actionCardIndex = 0,
+            targetPlayer1Id = player1Id,
+            targetPlayer1Row = 0,
+            targetPlayer1Col = 0,
+            targetPlayer2Id = player2Id,
+            targetPlayer2Row = 0,
+            targetPlayer2Col = 0,
+        )
 
     // ── round transitions ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Adds PlayerSwapCard to SkyjoCard.ActionCard sealed hierarchy
- Implements ActionCardEffect.PlayerSwap: swaps one occupied board slot between two different players (any visibility, face-up state preserved)
- Replaces all 21 Placeholder action cards in the deck with PlayerSwapCard
- Adds PLAY_ACTION_CARD and DISCARD_ACTION_CARD action types to GameActionMessage
- Exposes actionCardTypes per player in PlayerBoardDto

## Test plan
- ActionCardEffectTest: swap changes both boards, face-up preserved, same-player throws, cleared slot throws
- SkyjoDeckFactoryTest: all 21 action cards are PlayerSwapCard
- GameServiceTest: PLAY_ACTION_CARD and DISCARD_ACTION_CARD routed correctly