### PR TITLE
fix: lobby concurrency, atomic nickname uniqueness, error visibility

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -3,6 +3,7 @@ Raphael Bleier <raphaelbl@edu.aau.at> <hacksarenice@protonmail.com>
 Raphael Bleier <raphaelbl@edu.aau.at> <raphaelbl@edu.aau.at>
 Raphael Bleier <raphaelbl@edu.aau.at> <75416341+raphaelbleier@users.noreply.github.com>
 Raphael Bleier <raphaelbl@edu.aau.at> <raphaelbleier@users.noreply.github.com>
+Raphael Bleier <raphaelbl@edu.aau.at> <bleier.raphael@gmail.com>
 
 Jakob Keischnigg <jakobkei@edu.aau.at> <jakobkeischnigg@gmail.com>
 Jakob Keischnigg <jakobkei@edu.aau.at> <office@jksolutions.at>

--- a/src/main/kotlin/at/aau/se2/skyjo/controller/LobbyController.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/controller/LobbyController.kt
@@ -54,13 +54,8 @@ class LobbyController(
                 error("Name has to be between 1 and 15 characters.")
             }
 
-            // Uniqueness: Prüfen, ob der Name in der Lobby schon existiert
-            val currentState = lobbyService.getState()
-            if (currentState.players.any { it.nickname.equals(rawName, ignoreCase = true) }) {
-                error("Nickname '$rawName' is already in use")
-            }
-
-            // Wenn wir hier ankommen, ist der Name gültig und einzigartig!
+            // Uniqueness is enforced atomically inside lobbyService.join under its
+            // lock, so two concurrent joins with the same name cannot both pass.
             val nickname = rawName
 
             // Spieler der Lobby hinzufügen
@@ -73,8 +68,12 @@ class LobbyController(
             messagingTemplate.convertAndSendToUser(playerId, "/queue/lobby", state.toUpdateMessage())
 
         }.onFailure { e ->
-            // Fehler (z.B. Name zu kurz oder vergeben) an den jeweiligen Spieler zurücksenden
-            messagingTemplate.convertAndSendToUser(playerId, "/queue/errors", mapOf("message" to e.message))
+            logger.warn("lobby.join failed for $playerId", e)
+            messagingTemplate.convertAndSendToUser(
+                playerId,
+                "/queue/errors",
+                mapOf("message" to (e.message ?: "Could not join lobby")),
+            )
         }
     }
 
@@ -101,7 +100,12 @@ class LobbyController(
             val gameState = gameService.startGame(lobbyState.players, gameConfig)
             messagingTemplate.convertAndSend("/topic/game", gameState)
         }.onFailure { e ->
-            messagingTemplate.convertAndSendToUser(playerId, "/queue/errors", mapOf("message" to e.message))
+            logger.warn("game.start failed for $playerId", e)
+            messagingTemplate.convertAndSendToUser(
+                playerId,
+                "/queue/errors",
+                mapOf("message" to (e.message ?: "Could not start game")),
+            )
         }
     }
 }

--- a/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
@@ -46,9 +46,11 @@ class GameService(
     fun getActiveGameId(): String? = currentGameId
 
     fun markPlayerDisconnected(principalId: String) {
-        val nickname = playerInfo[principalId] ?: return
-        disconnectedNicknames.add(nickname)
-        gameRepository?.markDisconnected(nickname)
+        lock.withLock {
+            val nickname = playerInfo[principalId] ?: return@withLock
+            disconnectedNicknames.add(nickname)
+            gameRepository?.markDisconnected(nickname)
+        }
     }
 
     fun addSessionAlias(newSessionId: String, nickname: String): Boolean = lock.withLock {

--- a/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
@@ -23,6 +23,9 @@ class LobbyService {
         if (state.players.any { it.sessionId == sessionId }) {
             return state
         }
+        if (state.players.any { it.nickname.equals(nickname, ignoreCase = true) }) {
+            error("Nickname '$nickname' is already in use")
+        }
 
         val isHost = state.players.isEmpty()
         val player = LobbyPlayer(sessionId = sessionId, nickname = nickname, isHost = isHost)

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyControllerTest.kt
@@ -87,14 +87,12 @@ class LobbyControllerTest {
 
         @Test
         fun `joinLobby sendet Fehler, wenn Nickname bereits existiert (Case Insensitive)`() {
-            val currentState = mockk<LobbyState>()
-            val existingPlayer = mockk<LobbyPlayer> {
-                every { nickname } returns "ExistingName"
-            }
-            every { currentState.players } returns listOf(existingPlayer)
-            every { lobbyService.getState() } returns currentState
+            // Uniqueness is now enforced atomically inside lobbyService.join
+            // (under its lock) instead of via a racy check-then-act in the controller.
+            every {
+                lobbyService.join(any(), "existingname")
+            } throws IllegalStateException("Nickname 'existingname' is already in use")
 
-            // Versuch mit gleichem Namen beizutreten (kleingeschrieben)
             controller.joinLobby(PlayerMessage("existingname"), headerAccessor)
 
             verify {
@@ -104,7 +102,6 @@ class LobbyControllerTest {
                     mapOf("message" to "Nickname 'existingname' is already in use")
                 )
             }
-            verify(exactly = 0) { lobbyService.join(any(), any()) }
         }
 
         @Test

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyControllerTest.kt
@@ -12,7 +12,8 @@ import org.springframework.messaging.simp.SimpMessageSendingOperations
 import java.security.Principal
 import at.aau.se2.skyjo.service.*
 import at.aau.se2.skyjo.model.*
-import  at.aau.se2.skyjo.model.lobby.*
+import at.aau.se2.skyjo.model.lobby.*
+import at.aau.se2.skyjo.persistence.GameRepository
 
 @ExtendWith(MockKExtension::class)
 class LobbyControllerTest {
@@ -123,6 +124,37 @@ class LobbyControllerTest {
                     mapOf("message" to errorMessage)
                 )
             }
+        }
+
+        @Test
+        fun `joinLobby rejoin sends game state to player when state is available`() {
+            val mockRepository = mockk<GameRepository>(relaxed = true)
+            val controllerWithRepo = LobbyController(lobbyService, gameService, messagingTemplate, mockRepository)
+
+            every { mockRepository.getPlayerGame("Alice") } returns "game-123"
+            every { gameService.getActiveGameId() } returns "game-123"
+            every { gameService.addSessionAlias(playerId, "Alice") } returns true
+            val gameUpdateMessage = mockk<GameUpdateMessage>()
+            every { gameService.getCurrentState() } returns gameUpdateMessage
+
+            controllerWithRepo.joinLobby(PlayerMessage("Alice"), headerAccessor)
+
+            verify { messagingTemplate.convertAndSendToUser(playerId, "/queue/gamestate", gameUpdateMessage) }
+        }
+
+        @Test
+        fun `joinLobby rejoin skips game state message when getCurrentState returns null`() {
+            val mockRepository = mockk<GameRepository>(relaxed = true)
+            val controllerWithRepo = LobbyController(lobbyService, gameService, messagingTemplate, mockRepository)
+
+            every { mockRepository.getPlayerGame("Alice") } returns "game-123"
+            every { gameService.getActiveGameId() } returns "game-123"
+            every { gameService.addSessionAlias(playerId, "Alice") } returns true
+            every { gameService.getCurrentState() } returns null
+
+            controllerWithRepo.joinLobby(PlayerMessage("Alice"), headerAccessor)
+
+            verify(exactly = 0) { messagingTemplate.convertAndSendToUser(playerId, "/queue/gamestate", any()) }
         }
 
         @Test

--- a/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
@@ -281,6 +281,51 @@ class GameServiceTest {
 
         assertNotNull(service.getCurrentState())
     }
+
+    // ── markPlayerDisconnected ────────────────────────────────────────────
+
+    @Test
+    fun `markPlayerDisconnected with unknown session id does not add to disconnected list`() {
+        service.startGame(players)
+
+        service.markPlayerDisconnected("unknown-session")
+
+        val state = service.getCurrentState()!!
+        assertTrue(state.disconnectedPlayers.isEmpty())
+    }
+
+    @Test
+    fun `markPlayerDisconnected with known session id adds nickname to disconnected list`() {
+        service.startGame(players)
+
+        service.markPlayerDisconnected(player1Id)
+
+        val state = service.getCurrentState()!!
+        assertTrue(state.disconnectedPlayers.contains("Alice"))
+    }
+
+    // ── addSessionAlias ───────────────────────────────────────────────────
+
+    @Test
+    fun `addSessionAlias returns false when nickname not found in active game`() {
+        service.startGame(players)
+
+        val result = service.addSessionAlias("new-session", "NonExistent")
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `addSessionAlias returns true and removes nickname from disconnected list`() {
+        service.startGame(players)
+        service.markPlayerDisconnected(player1Id)
+        assertTrue(service.getCurrentState()!!.disconnectedPlayers.contains("Alice"))
+
+        val result = service.addSessionAlias("new-session-id", "Alice")
+
+        assertTrue(result)
+        assertFalse(service.getCurrentState()!!.disconnectedPlayers.contains("Alice"))
+    }
 }
 
 // Helpers to access internal state for test setup

--- a/src/test/kotlin/at/aau/se2/skyjo/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/LobbyServiceTest.kt
@@ -40,6 +40,14 @@ class LobbyServiceTest {
     }
 
     @Test
+    fun `joining with a nickname already in use throws error`() {
+        service.join("s1", "Alice")
+
+        val ex = assertThrows<IllegalStateException> { service.join("s2", "alice") }
+        assertTrue(ex.message!!.contains("already in use"))
+    }
+
+    @Test
     fun `joining full lobby throws error`() {
         for (i in 1..6) service.join("s$i", "Player$i")
 


### PR DESCRIPTION
Backend bug fixes found during a full audit alongside frontend issue [#33](https://github.com/aause2gruppe5/skyjo_aau26_se2_frontend/issues/33).

## Bugs fixed

### 1. (Critical) `markPlayerDisconnected()` mutated shared state outside the lock
`GameService.kt` — `disconnectedNicknames` (plain `mutableSetOf`) and `playerInfo` were mutated/read **without** `lock.withLock`, while `toUpdateMessage()` and `addSessionAlias()` touch the same collections under the lock. A WebSocket disconnect concurrent with a game action could throw `ConcurrentModificationException` or read torn state, crashing the `/topic/game` broadcast.

**Fix:** wrap the body in `lock.withLock`.

### 2. (High) Lobby nickname uniqueness was a check-then-act race
`LobbyController.joinLobby` did `lobbyService.getState()` then `lobbyService.join()` — two separate lock acquisitions. Two players joining the same nickname concurrently could both pass the check. This also feeds issue #33: a reconnecting player re-sending `lobby.join` while their stale session lingers got "Nickname already in use" and the client could react by disconnecting.

**Fix:** moved the uniqueness check **inside** `LobbyService.join`, under the single existing lock (after the same-session idempotency check). Removed the racy controller pre-check.

### 3. (Medium) Error handlers hid real failures
`onFailure` sent `mapOf("message" to e.message)` — `null` for NPE-style exceptions — and never logged the throwable server-side.

**Fix:** `logger.warn(..., e)` plus a non-null fallback message.

## Notes / out of scope

The deeper architectural root cause of #33 — `WebSocketConfig` minting a fresh random principal on every handshake with no lobby-level reconnection/alias — needs a coordinated FE+BE stable-client-id change and is intentionally **not** in this PR. The frontend PR (frontend #34) removes the socket churn that triggers the symptom; these backend fixes harden the concurrency and error paths around it.

## Test plan
- [x] New `LobbyServiceTest`: joining with an in-use nickname (case-insensitive) throws
- [x] `LobbyControllerTest` uniqueness test updated to reflect service-level enforcement
- [x] Existing lobby/game/service tests pass
- [x] CI green