### PR TITLE
Fix backend Docker build context for deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,9 @@
 .git
 .github
 .gradle
-build/
+build/*
+!build/libs/
+!build/libs/*.jar
 bin/
 *.md
 gradlew.bat


### PR DESCRIPTION
## Summary
- keep most Gradle build output ignored by Docker
- allow the generated bootJar under build/libs into the Docker build context
- fixes deploy workflow image build failing at COPY build/libs/*.jar app.jar

## Test Plan
- ./gradlew clean bootJar -x test
- docker build --no-cache -t skyjo-backend-ci-fix .
- ./gradlew test