### PR TITLE
fix: reset lobby when all players leave during game

### DIFF
--- a/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
@@ -37,7 +37,8 @@ class LobbyService {
         } else {
             players
         }
-        state = state.copy(players = reassigned)
+        val newStatus = if (reassigned.isEmpty()) LobbyStatus.WAITING else state.status
+        state = state.copy(players = reassigned, status = newStatus)
         state
     }
 

--- a/src/test/kotlin/at/aau/se2/skyjo/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/LobbyServiceTest.kt
@@ -141,4 +141,44 @@ class LobbyServiceTest {
     fun `isPlayerInLobby returns false for unknown player`() {
         assertFalse(service.isPlayerInLobby("unknown"))
     }
+
+    @Test
+    fun `all players leaving during game resets status to WAITING`() {
+        service.join("s1", "Alice")
+        service.join("s2", "Bob")
+        service.startGame("s1")
+
+        service.leave("s1")
+        val state = service.leave("s2")
+
+        assertEquals(LobbyStatus.WAITING, state.status)
+        assertEquals(0, state.players.size)
+    }
+
+    @Test
+    fun `new players can join after all players leave during game`() {
+        service.join("s1", "Alice")
+        service.join("s2", "Bob")
+        service.startGame("s1")
+        service.leave("s1")
+        service.leave("s2")
+
+        val state = service.join("s3", "Charlie")
+
+        assertEquals(1, state.players.size)
+        assertTrue(state.players[0].isHost)
+        assertEquals("Charlie", state.players[0].nickname)
+    }
+
+    @Test
+    fun `one player leaving during game keeps IN_GAME status`() {
+        service.join("s1", "Alice")
+        service.join("s2", "Bob")
+        service.startGame("s1")
+
+        val state = service.leave("s1")
+
+        assertEquals(LobbyStatus.IN_GAME, state.status)
+        assertEquals(1, state.players.size)
+    }
 }


### PR DESCRIPTION
## Summary
- `LobbyService.leave()` now resets lobby status to `WAITING` when the last player leaves, even if a game was in progress
- Prevents lobby from getting stuck in `IN_GAME` state with zero players after both players disconnect
- New players with fresh nicknames can now join and start a new game

## Test plan
- [x] `all players leaving during game resets status to WAITING`
- [x] `new players can join after all players leave during game`
- [x] `one player leaving during game keeps IN_GAME status` (regression)
- [x] All existing `LobbyServiceTest` tests still pass