### PR TITLE
Add authenticated lobby, social, and leaderboard backend

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-websocket")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
+    implementation("org.springframework.security:spring-security-crypto")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     runtimeOnly("org.xerial:sqlite-jdbc:3.47.0.0")

--- a/src/main/kotlin/at/aau/se2/skyjo/config/AppConfig.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/config/AppConfig.kt
@@ -1,6 +1,8 @@
 package at.aau.se2.skyjo.config
 
 import at.aau.se2.skyjo.game.service.SkyjoEngine
+import at.aau.se2.skyjo.persistence.LobbyRepository
+import at.aau.se2.skyjo.service.LobbyService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -8,4 +10,7 @@ import org.springframework.context.annotation.Configuration
 class AppConfig {
     @Bean
     fun skyjoEngine(): SkyjoEngine = SkyjoEngine()
+
+    @Bean
+    fun lobbyService(lobbyRepository: LobbyRepository): LobbyService = LobbyService(repository = lobbyRepository)
 }

--- a/src/main/kotlin/at/aau/se2/skyjo/config/WebSocketConfig.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/config/WebSocketConfig.kt
@@ -4,12 +4,15 @@ import at.aau.se2.skyjo.model.auth.AuthPrincipal
 import at.aau.se2.skyjo.service.AuthService
 import at.aau.se2.skyjo.service.UnauthorizedException
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpStatus
 import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
 import org.springframework.messaging.simp.config.MessageBrokerRegistry
 import org.springframework.web.socket.WebSocketHandler
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+import org.springframework.web.socket.server.HandshakeInterceptor
 import org.springframework.web.socket.server.support.DefaultHandshakeHandler
 import java.net.URLDecoder
 import java.security.Principal
@@ -29,41 +32,64 @@ class WebSocketConfig(
     override fun registerStompEndpoints(registry: StompEndpointRegistry) {
         registry.addEndpoint("/ws")
             .setAllowedOriginPatterns("*")
-            .setHandshakeHandler(AuthPrincipalHandshakeHandler(authService))
+            .addInterceptors(TicketHandshakeInterceptor(authService))
+            .setHandshakeHandler(AuthPrincipalHandshakeHandler())
     }
 }
 
-class AuthPrincipalHandshakeHandler(
+class TicketHandshakeInterceptor(
     private val authService: AuthService,
-) : DefaultHandshakeHandler() {
-    override fun determineUser(
-        request: ServerHttpRequest,
-        wsHandler: WebSocketHandler,
-        attributes: Map<String, Any>,
-    ): Principal = determinePrincipal(request)
+) : HandshakeInterceptor {
 
-    fun determinePrincipal(request: ServerHttpRequest): Principal {
-        val ticket = extractTicket(request) ?: throw UnauthorizedException()
-        val user = authService.consumeWebSocketTicket(ticket) ?: throw UnauthorizedException()
-        return AuthPrincipal(userId = user.userId, username = user.username)
+    override fun beforeHandshake(
+        request: ServerHttpRequest,
+        response: ServerHttpResponse,
+        wsHandler: WebSocketHandler,
+        attributes: MutableMap<String, Any>,
+    ): Boolean {
+        val ticket = extractTicket(request)
+        val user = if (ticket != null) authService.consumeWebSocketTicket(ticket) else null
+        return if (user != null) {
+            attributes[ATTR_PRINCIPAL] = AuthPrincipal(userId = user.userId, username = user.username)
+            true
+        } else {
+            response.setStatusCode(HttpStatus.UNAUTHORIZED)
+            false
+        }
     }
 
-    private fun extractTicket(request: ServerHttpRequest): String? {
+    override fun afterHandshake(
+        request: ServerHttpRequest,
+        response: ServerHttpResponse,
+        wsHandler: WebSocketHandler,
+        exception: Exception?,
+    ) {}
+
+    internal fun extractTicket(request: ServerHttpRequest): String? {
         val rawQuery = request.uri.rawQuery ?: return null
         return rawQuery
             .split("&")
             .asSequence()
             .mapNotNull { parameter ->
                 val separatorIndex = parameter.indexOf("=")
-                if (separatorIndex <= 0) {
-                    null
-                } else {
-                    parameter.substring(0, separatorIndex) to parameter.substring(separatorIndex + 1)
-                }
+                if (separatorIndex <= 0) null
+                else parameter.substring(0, separatorIndex) to parameter.substring(separatorIndex + 1)
             }
             .firstOrNull { (key, _) -> key == "ticket" }
             ?.second
             ?.let { URLDecoder.decode(it, Charsets.UTF_8.name()) }
             ?.ifBlank { null }
     }
+
+    companion object {
+        const val ATTR_PRINCIPAL = "ws_principal"
+    }
+}
+
+class AuthPrincipalHandshakeHandler : DefaultHandshakeHandler() {
+    public override fun determineUser(
+        request: ServerHttpRequest,
+        wsHandler: WebSocketHandler,
+        attributes: Map<String, Any>,
+    ): Principal? = attributes[TicketHandshakeInterceptor.ATTR_PRINCIPAL] as? Principal
 }

--- a/src/main/kotlin/at/aau/se2/skyjo/config/WebSocketConfig.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/config/WebSocketConfig.kt
@@ -1,5 +1,8 @@
 package at.aau.se2.skyjo.config
 
+import at.aau.se2.skyjo.model.auth.AuthPrincipal
+import at.aau.se2.skyjo.service.AuthService
+import at.aau.se2.skyjo.service.UnauthorizedException
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.server.ServerHttpRequest
 import org.springframework.messaging.simp.config.MessageBrokerRegistry
@@ -8,12 +11,14 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
 import org.springframework.web.socket.server.support.DefaultHandshakeHandler
+import java.net.URLDecoder
 import java.security.Principal
-import java.util.UUID
 
 @Configuration
 @EnableWebSocketMessageBroker
-class WebSocketConfig : WebSocketMessageBrokerConfigurer {
+class WebSocketConfig(
+    private val authService: AuthService,
+) : WebSocketMessageBrokerConfigurer {
 
     override fun configureMessageBroker(config: MessageBrokerRegistry) {
         config.enableSimpleBroker("/topic", "/queue")
@@ -24,17 +29,41 @@ class WebSocketConfig : WebSocketMessageBrokerConfigurer {
     override fun registerStompEndpoints(registry: StompEndpointRegistry) {
         registry.addEndpoint("/ws")
             .setAllowedOriginPatterns("*")
-            .setHandshakeHandler(SessionPrincipalHandshakeHandler())
+            .setHandshakeHandler(AuthPrincipalHandshakeHandler(authService))
     }
 }
 
-private class SessionPrincipalHandshakeHandler : DefaultHandshakeHandler() {
+class AuthPrincipalHandshakeHandler(
+    private val authService: AuthService,
+) : DefaultHandshakeHandler() {
     override fun determineUser(
         request: ServerHttpRequest,
         wsHandler: WebSocketHandler,
         attributes: Map<String, Any>,
-    ): Principal {
-        val id = UUID.randomUUID().toString()
-        return Principal { id }
+    ): Principal = determinePrincipal(request)
+
+    fun determinePrincipal(request: ServerHttpRequest): Principal {
+        val ticket = extractTicket(request) ?: throw UnauthorizedException()
+        val user = authService.consumeWebSocketTicket(ticket) ?: throw UnauthorizedException()
+        return AuthPrincipal(userId = user.userId, username = user.username)
+    }
+
+    private fun extractTicket(request: ServerHttpRequest): String? {
+        val rawQuery = request.uri.rawQuery ?: return null
+        return rawQuery
+            .split("&")
+            .asSequence()
+            .mapNotNull { parameter ->
+                val separatorIndex = parameter.indexOf("=")
+                if (separatorIndex <= 0) {
+                    null
+                } else {
+                    parameter.substring(0, separatorIndex) to parameter.substring(separatorIndex + 1)
+                }
+            }
+            .firstOrNull { (key, _) -> key == "ticket" }
+            ?.second
+            ?.let { URLDecoder.decode(it, Charsets.UTF_8.name()) }
+            ?.ifBlank { null }
     }
 }

--- a/src/main/kotlin/at/aau/se2/skyjo/controller/AuthController.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/controller/AuthController.kt
@@ -1,0 +1,69 @@
+package at.aau.se2.skyjo.controller
+
+import at.aau.se2.skyjo.model.auth.ErrorResponse
+import at.aau.se2.skyjo.model.auth.LoginRequest
+import at.aau.se2.skyjo.model.auth.RegisterRequest
+import at.aau.se2.skyjo.service.AuthService
+import at.aau.se2.skyjo.service.DuplicateUsernameException
+import at.aau.se2.skyjo.service.InvalidAuthInputException
+import at.aau.se2.skyjo.service.InvalidCredentialsException
+import at.aau.se2.skyjo.service.UnauthorizedException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/auth")
+class AuthController(
+    private val authService: AuthService,
+    private val authSupport: AuthSupport,
+) {
+
+    @PostMapping("/register")
+    fun register(@RequestBody request: RegisterRequest): ResponseEntity<Any> =
+        try {
+            ResponseEntity.status(HttpStatus.CREATED).body(authService.register(request.username, request.password))
+        } catch (e: DuplicateUsernameException) {
+            ResponseEntity.status(HttpStatus.CONFLICT).body(ErrorResponse(e.message ?: "Username is already taken"))
+        } catch (e: InvalidAuthInputException) {
+            ResponseEntity.badRequest().body(ErrorResponse(e.message ?: "Invalid registration data"))
+        }
+
+    @PostMapping("/login")
+    fun login(@RequestBody request: LoginRequest): ResponseEntity<Any> =
+        try {
+            ResponseEntity.ok(authService.login(request.username, request.password))
+        } catch (e: InvalidCredentialsException) {
+            ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorResponse(e.message ?: "Invalid username or password"))
+        }
+
+    @PostMapping("/logout")
+    fun logout(@RequestHeader("Authorization") authorizationHeader: String?): ResponseEntity<Void> {
+        val token = authSupport.extractBearerToken(authorizationHeader)
+            ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        authService.logout(token)
+        return ResponseEntity.noContent().build()
+    }
+
+    @GetMapping("/me")
+    fun me(@RequestHeader("Authorization") authorizationHeader: String?): ResponseEntity<Any> =
+        try {
+            ResponseEntity.ok(authSupport.requireUser(authorizationHeader))
+        } catch (e: UnauthorizedException) {
+            ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorResponse(e.message ?: "Authentication required"))
+        }
+
+    @PostMapping("/ws-ticket")
+    fun createWebSocketTicket(@RequestHeader("Authorization") authorizationHeader: String?): ResponseEntity<Any> =
+        try {
+            val token = authSupport.extractBearerToken(authorizationHeader) ?: throw UnauthorizedException()
+            ResponseEntity.ok(authService.createWebSocketTicket(token))
+        } catch (e: UnauthorizedException) {
+            ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ErrorResponse(e.message ?: "Authentication required"))
+        }
+}

--- a/src/main/kotlin/at/aau/se2/skyjo/controller/AuthSupport.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/controller/AuthSupport.kt
@@ -24,6 +24,10 @@ class AuthSupport(
         return authService.requireUser(token)
     }
 
+    fun markUserConnected(userId: String, currentLobbyId: String?) {
+        authService.markUserConnected(userId, currentLobbyId)
+    }
+
     companion object {
         private const val BEARER_PREFIX = "Bearer "
     }

--- a/src/main/kotlin/at/aau/se2/skyjo/controller/AuthSupport.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/controller/AuthSupport.kt
@@ -1,0 +1,30 @@
+package at.aau.se2.skyjo.controller
+
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.service.AuthService
+import at.aau.se2.skyjo.service.UnauthorizedException
+import org.springframework.stereotype.Component
+
+@Component
+class AuthSupport(
+    private val authService: AuthService,
+) {
+
+    fun extractBearerToken(authorizationHeader: String?): String? {
+        val header = authorizationHeader?.trim() ?: return null
+        if (!header.startsWith(BEARER_PREFIX, ignoreCase = true)) {
+            return null
+        }
+        val token = header.substring(BEARER_PREFIX.length).trim()
+        return token.ifEmpty { null }
+    }
+
+    fun requireUser(authorizationHeader: String?): AuthUserDto {
+        val token = extractBearerToken(authorizationHeader) ?: throw UnauthorizedException()
+        return authService.requireUser(token)
+    }
+
+    companion object {
+        private const val BEARER_PREFIX = "Bearer "
+    }
+}

--- a/src/main/kotlin/at/aau/se2/skyjo/controller/FriendController.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/controller/FriendController.kt
@@ -1,0 +1,94 @@
+package at.aau.se2.skyjo.controller
+
+import at.aau.se2.skyjo.model.auth.ErrorResponse
+import at.aau.se2.skyjo.model.social.SendFriendRequestRequest
+import at.aau.se2.skyjo.service.FriendService
+import at.aau.se2.skyjo.service.UnauthorizedException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class FriendController(
+    private val friendService: FriendService,
+    private val authSupport: AuthSupport,
+) {
+
+    @GetMapping("/api/users/search")
+    fun searchUsers(
+        @RequestParam query: String,
+        @RequestHeader("Authorization") authorizationHeader: String?,
+    ): ResponseEntity<Any> =
+        runCatching {
+            val user = authSupport.requireUser(authorizationHeader)
+            ResponseEntity.ok(friendService.searchUsers(user, query) as Any)
+        }.getOrElse(::toSocialError)
+
+    @GetMapping("/api/friends")
+    fun listFriends(
+        @RequestHeader("Authorization") authorizationHeader: String?,
+    ): ResponseEntity<Any> =
+        runCatching {
+            val user = authSupport.requireUser(authorizationHeader)
+            ResponseEntity.ok(friendService.listFriends(user) as Any)
+        }.getOrElse(::toSocialError)
+
+    @GetMapping("/api/friends/requests")
+    fun listFriendRequests(
+        @RequestHeader("Authorization") authorizationHeader: String?,
+    ): ResponseEntity<Any> =
+        runCatching {
+            val user = authSupport.requireUser(authorizationHeader)
+            ResponseEntity.ok(friendService.listFriendRequests(user) as Any)
+        }.getOrElse(::toSocialError)
+
+    @PostMapping("/api/friends/requests")
+    fun sendFriendRequest(
+        @RequestBody request: SendFriendRequestRequest,
+        @RequestHeader("Authorization") authorizationHeader: String?,
+    ): ResponseEntity<Any> =
+        runCatching {
+            val user = authSupport.requireUser(authorizationHeader)
+            ResponseEntity.status(HttpStatus.CREATED).body(friendService.sendFriendRequest(user, request.toUserId) as Any)
+        }.getOrElse(::toSocialError)
+
+    @PostMapping("/api/friends/requests/{requestId}/accept")
+    fun acceptFriendRequest(
+        @PathVariable requestId: String,
+        @RequestHeader("Authorization") authorizationHeader: String?,
+    ): ResponseEntity<Any> =
+        runCatching {
+            val user = authSupport.requireUser(authorizationHeader)
+            ResponseEntity.ok(friendService.acceptFriendRequest(user, requestId) as Any)
+        }.getOrElse(::toSocialError)
+
+    @PostMapping("/api/friends/requests/{requestId}/decline")
+    fun declineFriendRequest(
+        @PathVariable requestId: String,
+        @RequestHeader("Authorization") authorizationHeader: String?,
+    ): ResponseEntity<Any> =
+        runCatching {
+            val user = authSupport.requireUser(authorizationHeader)
+            ResponseEntity.ok(friendService.declineFriendRequest(user, requestId) as Any)
+        }.getOrElse(::toSocialError)
+}
+
+private fun toSocialError(error: Throwable): ResponseEntity<Any> =
+    when (error) {
+        is UnauthorizedException -> ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(ErrorResponse(error.message ?: "Authentication required"))
+        is IllegalStateException ->
+            if (error.message?.contains("not found", ignoreCase = true) == true) {
+                ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse(error.message ?: "not found"))
+            } else {
+                ResponseEntity.badRequest().body(ErrorResponse(error.message ?: "invalid social operation"))
+            }
+        else -> ResponseEntity.badRequest().body(ErrorResponse(error.message ?: "invalid social operation"))
+    }

--- a/src/main/kotlin/at/aau/se2/skyjo/controller/GameController.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/controller/GameController.kt
@@ -27,7 +27,7 @@ class GameController(
         runCatching {
             val updatedState = gameService.processAction(playerId, action)
             logger.info("Game action ${action.type} by $playerId")
-            messagingTemplate.convertAndSend("/topic/game", updatedState)
+            messagingTemplate.convertAndSend(updatedState.topicPath(), updatedState)
         }.onFailure { e ->
             messagingTemplate.convertAndSendToUser(playerId, "/queue/errors", mapOf("message" to e.message))
         }
@@ -42,7 +42,7 @@ class GameController(
         runCatching {
             val result = gameService.playActionCard(playerId, command)
             logger.info("Action card ${command.actionCardIndex} played by $playerId")
-            messagingTemplate.convertAndSend("/topic/game", result.gameUpdate)
+            messagingTemplate.convertAndSend(result.gameUpdate.topicPath(), result.gameUpdate)
             result.privateActionCardResults.forEach { (recipientPlayerId, actionCardResult) ->
                 messagingTemplate.convertAndSendToUser(
                     recipientPlayerId,
@@ -54,4 +54,7 @@ class GameController(
             messagingTemplate.convertAndSendToUser(playerId, "/queue/errors", mapOf("message" to e.message))
         }
     }
+
+    private fun at.aau.se2.skyjo.model.GameUpdateMessage.topicPath(): String =
+        gameId?.let { "/topic/games/$it" } ?: "/topic/game"
 }

--- a/src/main/kotlin/at/aau/se2/skyjo/controller/LobbyController.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/controller/LobbyController.kt
@@ -6,15 +6,24 @@ import at.aau.se2.skyjo.model.LobbyUpdateMessage
 import at.aau.se2.skyjo.model.PlayerMessage
 import at.aau.se2.skyjo.model.StartGameMessage
 import at.aau.se2.skyjo.model.lobby.LobbyState
+import at.aau.se2.skyjo.model.auth.ErrorResponse
+import at.aau.se2.skyjo.model.lobby.LobbySummaryResponse
 import at.aau.se2.skyjo.persistence.GameRepository
 import at.aau.se2.skyjo.service.GameService
 import at.aau.se2.skyjo.service.LobbyService
+import at.aau.se2.skyjo.service.UnauthorizedException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.slf4j.LoggerFactory
 import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessageSendingOperations
 import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestHeader
 
 @Controller
 class LobbyController(
@@ -22,6 +31,7 @@ class LobbyController(
     private val gameService: GameService,
     private val messagingTemplate: SimpMessageSendingOperations,
     private val gameRepository: GameRepository?,
+    private val authSupport: AuthSupport? = null,
 ) {
 
     private val logger = LoggerFactory.getLogger(LobbyController::class.java)
@@ -78,6 +88,54 @@ class LobbyController(
         }
     }
 
+    @PostMapping("/api/lobbies")
+    fun createLobby(
+        @RequestHeader("Authorization") authorizationHeader: String?,
+    ): ResponseEntity<Any> =
+        runCatching {
+            val user = requireAuthSupport().requireUser(authorizationHeader)
+            val lobby = lobbyService.createLobby(user)
+            messagingTemplate.convertAndSend("/topic/lobbies/${lobby.joinCode}", lobby.toUpdateMessage())
+            ResponseEntity.status(HttpStatus.CREATED).body(lobby.toSummaryResponse() as Any)
+        }.getOrElse(::toRestError)
+
+    @PostMapping("/api/lobbies/{joinCode}/join")
+    fun joinLobbyByCode(
+        @PathVariable joinCode: String,
+        @RequestHeader("Authorization") authorizationHeader: String?,
+    ): ResponseEntity<Any> =
+        runCatching {
+            val user = requireAuthSupport().requireUser(authorizationHeader)
+            val lobby = lobbyService.joinLobby(user, joinCode)
+            messagingTemplate.convertAndSend("/topic/lobbies/${lobby.joinCode}", lobby.toUpdateMessage())
+            ResponseEntity.ok(lobby.toSummaryResponse() as Any)
+        }.getOrElse(::toRestError)
+
+    @PostMapping("/api/lobbies/{lobbyId}/leave")
+    fun leaveLobbyById(
+        @PathVariable lobbyId: String,
+        @RequestHeader("Authorization") authorizationHeader: String?,
+    ): ResponseEntity<Any> =
+        runCatching {
+            val user = requireAuthSupport().requireUser(authorizationHeader)
+            val lobby = lobbyService.leaveLobby(user.userId, lobbyId)
+            lobby.joinCode?.let { code ->
+                messagingTemplate.convertAndSend("/topic/lobbies/$code", lobby.toUpdateMessage())
+            }
+            ResponseEntity.ok(lobby.toSummaryResponse() as Any)
+        }.getOrElse(::toRestError)
+
+    @GetMapping("/api/lobbies/current")
+    fun currentLobby(
+        @RequestHeader("Authorization") authorizationHeader: String?,
+    ): ResponseEntity<Any> =
+        runCatching {
+            val user = requireAuthSupport().requireUser(authorizationHeader)
+            val lobby = lobbyService.getCurrentLobbyForUser(user.userId)
+                ?: return ResponseEntity.noContent().build<Any>()
+            ResponseEntity.ok(lobby.toSummaryResponse() as Any)
+        }.getOrElse(::toRestError)
+
     @MessageMapping("/lobby.leave")
     fun leaveLobby(headerAccessor: SimpMessageHeaderAccessor) {
         val playerId = headerAccessor.user?.name ?: return
@@ -104,10 +162,37 @@ class LobbyController(
             messagingTemplate.convertAndSendToUser(playerId, "/queue/errors", mapOf("message" to e.message))
         }
     }
+
+    private fun requireAuthSupport(): AuthSupport =
+        authSupport ?: throw UnauthorizedException()
 }
 
 private fun LobbyState.toUpdateMessage() = LobbyUpdateMessage(
+    lobbyId = lobbyId,
+    joinCode = joinCode,
     players = players.map { LobbyPlayerInfo(nickname = it.nickname, isHost = it.isHost) },
     status = status,
     maxPlayers = maxPlayers,
 )
+
+private fun LobbyState.toSummaryResponse() = LobbySummaryResponse(
+    lobbyId = requireNotNull(lobbyId) { "lobby id is missing" },
+    joinCode = requireNotNull(joinCode) { "join code is missing" },
+    players = players.map { LobbyPlayerInfo(nickname = it.nickname, isHost = it.isHost) },
+    status = status,
+    maxPlayers = maxPlayers,
+)
+
+private fun toRestError(error: Throwable): ResponseEntity<Any> =
+    when (error) {
+        is UnauthorizedException -> ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(ErrorResponse(error.message ?: "Authentication required"))
+        is IllegalStateException ->
+            if (error.message?.contains("not found", ignoreCase = true) == true) {
+                ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse(error.message ?: "lobby not found"))
+            } else {
+                ResponseEntity.badRequest().body(ErrorResponse(error.message ?: "invalid lobby operation"))
+            }
+        else -> ResponseEntity.badRequest().body(ErrorResponse(error.message ?: "invalid lobby operation"))
+    }

--- a/src/main/kotlin/at/aau/se2/skyjo/controller/LobbyController.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/controller/LobbyController.kt
@@ -164,6 +164,9 @@ class LobbyController(
                 ?.let { lobbyId -> gameService.startGame(lobbyId, lobbyState.players, gameConfig) }
                 ?: gameService.startGame(lobbyState.players, gameConfig)
             messagingTemplate.convertAndSend(gameState.topicPath(), gameState)
+            lobbyState.players.forEach { player ->
+                messagingTemplate.convertAndSendToUser(player.userId, "/queue/gamestate", gameState)
+            }
         }.onFailure { e ->
             messagingTemplate.convertAndSendToUser(playerId, "/queue/errors", mapOf("message" to e.message))
         }

--- a/src/main/kotlin/at/aau/se2/skyjo/controller/LobbyController.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/controller/LobbyController.kt
@@ -1,6 +1,7 @@
 package at.aau.se2.skyjo.controller
 
 import at.aau.se2.skyjo.model.GameConfig
+import at.aau.se2.skyjo.model.GameUpdateMessage
 import at.aau.se2.skyjo.model.LobbyPlayerInfo
 import at.aau.se2.skyjo.model.LobbyUpdateMessage
 import at.aau.se2.skyjo.model.PlayerMessage
@@ -151,13 +152,18 @@ class LobbyController(
     ) {
         val playerId = headerAccessor.user?.name ?: return
         runCatching {
-            val lobbyState = lobbyService.startGame(playerId)
+            val currentLobby = runCatching { lobbyService.getCurrentLobbyForUser(playerId) }.getOrNull()
+            val lobbyState = currentLobby?.lobbyId
+                ?.let { lobbyId -> lobbyService.startGame(userId = playerId, lobbyId = lobbyId) }
+                ?: lobbyService.startGame(playerId)
             val gameConfig = message?.let { GameConfig(maxRounds = it.maxRounds, targetScore = it.targetScore) }
                 ?: GameConfig()
             logger.info("Game started by host $playerId (maxRounds=${gameConfig.maxRounds}, targetScore=${gameConfig.targetScore})")
-            messagingTemplate.convertAndSend("/topic/lobby", lobbyState.toUpdateMessage())
-            val gameState = gameService.startGame(lobbyState.players, gameConfig)
-            messagingTemplate.convertAndSend("/topic/game", gameState)
+            messagingTemplate.convertAndSend(lobbyState.topicPath(), lobbyState.toUpdateMessage())
+            val gameState = lobbyState.lobbyId
+                ?.let { lobbyId -> gameService.startGame(lobbyId, lobbyState.players, gameConfig) }
+                ?: gameService.startGame(lobbyState.players, gameConfig)
+            messagingTemplate.convertAndSend(gameState.topicPath(), gameState)
         }.onFailure { e ->
             messagingTemplate.convertAndSendToUser(playerId, "/queue/errors", mapOf("message" to e.message))
         }
@@ -174,6 +180,12 @@ private fun LobbyState.toUpdateMessage() = LobbyUpdateMessage(
     status = status,
     maxPlayers = maxPlayers,
 )
+
+private fun LobbyState.topicPath(): String =
+    joinCode?.let { "/topic/lobbies/$it" } ?: "/topic/lobby"
+
+private fun GameUpdateMessage.topicPath(): String =
+    gameId?.let { "/topic/games/$it" } ?: "/topic/game"
 
 private fun LobbyState.toSummaryResponse() = LobbySummaryResponse(
     lobbyId = requireNotNull(lobbyId) { "lobby id is missing" },

--- a/src/main/kotlin/at/aau/se2/skyjo/controller/LobbyController.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/controller/LobbyController.kt
@@ -45,16 +45,16 @@ class LobbyController(
         val playerId = headerAccessor.user?.name ?: return
 
         // Rejoin: Spieler hat eine aktive Game-Session → Spiel wiederherstellen
-        val storedGameId = gameRepository?.getPlayerGame(message.playerName)
-        if (storedGameId != null && storedGameId == gameService.getActiveGameId()) {
-            gameRepository?.savePlayerSession(message.playerName, storedGameId, connected = true)
-            gameService.addSessionAlias(playerId, message.playerName)
-            val state = gameService.getCurrentState()
+        val storedGameId = gameRepository?.getPlayerGame(playerId)
+            ?: gameRepository?.getPlayerGame(message.playerName)
+        if (storedGameId != null) {
+            val state = gameService.reconnectPlayer(playerId, message.playerName, storedGameId)
             if (state != null) {
                 messagingTemplate.convertAndSendToUser(playerId, "/queue/gamestate", state)
+                logger.info("Player rejoined: ${message.playerName} (principalId=$playerId, gameId=$storedGameId)")
+                return
             }
-            logger.info("Player rejoined: ${message.playerName} (newSessionId=$playerId, gameId=$storedGameId)")
-            return
+            logger.info("Stored game session is not active for reconnect: ${message.playerName} (principalId=$playerId, gameId=$storedGameId)")
         }
 
         runCatching {
@@ -94,8 +94,10 @@ class LobbyController(
         @RequestHeader("Authorization") authorizationHeader: String?,
     ): ResponseEntity<Any> =
         runCatching {
-            val user = requireAuthSupport().requireUser(authorizationHeader)
+            val auth = requireAuthSupport()
+            val user = auth.requireUser(authorizationHeader)
             val lobby = lobbyService.createLobby(user)
+            auth.markUserConnected(user.userId, lobby.lobbyId)
             messagingTemplate.convertAndSend("/topic/lobbies/${lobby.joinCode}", lobby.toUpdateMessage())
             ResponseEntity.status(HttpStatus.CREATED).body(lobby.toSummaryResponse() as Any)
         }.getOrElse(::toRestError)
@@ -106,8 +108,10 @@ class LobbyController(
         @RequestHeader("Authorization") authorizationHeader: String?,
     ): ResponseEntity<Any> =
         runCatching {
-            val user = requireAuthSupport().requireUser(authorizationHeader)
+            val auth = requireAuthSupport()
+            val user = auth.requireUser(authorizationHeader)
             val lobby = lobbyService.joinLobby(user, joinCode)
+            auth.markUserConnected(user.userId, lobby.lobbyId)
             messagingTemplate.convertAndSend("/topic/lobbies/${lobby.joinCode}", lobby.toUpdateMessage())
             ResponseEntity.ok(lobby.toSummaryResponse() as Any)
         }.getOrElse(::toRestError)
@@ -118,8 +122,10 @@ class LobbyController(
         @RequestHeader("Authorization") authorizationHeader: String?,
     ): ResponseEntity<Any> =
         runCatching {
-            val user = requireAuthSupport().requireUser(authorizationHeader)
+            val auth = requireAuthSupport()
+            val user = auth.requireUser(authorizationHeader)
             val lobby = lobbyService.leaveLobby(user.userId, lobbyId)
+            auth.markUserConnected(user.userId, null)
             lobby.joinCode?.let { code ->
                 messagingTemplate.convertAndSend("/topic/lobbies/$code", lobby.toUpdateMessage())
             }

--- a/src/main/kotlin/at/aau/se2/skyjo/controller/LobbyInviteController.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/controller/LobbyInviteController.kt
@@ -1,0 +1,79 @@
+package at.aau.se2.skyjo.controller
+
+import at.aau.se2.skyjo.model.auth.ErrorResponse
+import at.aau.se2.skyjo.model.social.LobbyInviteRequest
+import at.aau.se2.skyjo.service.LobbyInviteService
+import at.aau.se2.skyjo.service.UnauthorizedException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.messaging.simp.SimpMessageSendingOperations
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class LobbyInviteController(
+    private val inviteService: LobbyInviteService,
+    private val authSupport: AuthSupport,
+    private val messagingTemplate: SimpMessageSendingOperations,
+) {
+
+    @PostMapping("/api/lobbies/{lobbyId}/invites")
+    fun createInvite(
+        @PathVariable lobbyId: String,
+        @RequestBody request: LobbyInviteRequest,
+        @RequestHeader("Authorization") authorizationHeader: String?,
+    ): ResponseEntity<Any> =
+        runCatching {
+            val user = authSupport.requireUser(authorizationHeader)
+            val invite = inviteService.createInvite(user, lobbyId, request.toUserId)
+            messagingTemplate.convertAndSendToUser(invite.to.userId, "/queue/invites", invite)
+            ResponseEntity.status(HttpStatus.CREATED).body(invite as Any)
+        }.getOrElse(::toInviteError)
+
+    @GetMapping("/api/lobbies/invites")
+    fun listInvites(
+        @RequestHeader("Authorization") authorizationHeader: String?,
+    ): ResponseEntity<Any> =
+        runCatching {
+            val user = authSupport.requireUser(authorizationHeader)
+            ResponseEntity.ok(inviteService.listInvites(user) as Any)
+        }.getOrElse(::toInviteError)
+
+    @PostMapping("/api/lobbies/invites/{inviteId}/accept")
+    fun acceptInvite(
+        @PathVariable inviteId: String,
+        @RequestHeader("Authorization") authorizationHeader: String?,
+    ): ResponseEntity<Any> =
+        runCatching {
+            val user = authSupport.requireUser(authorizationHeader)
+            ResponseEntity.ok(inviteService.acceptInvite(user, inviteId) as Any)
+        }.getOrElse(::toInviteError)
+
+    @PostMapping("/api/lobbies/invites/{inviteId}/decline")
+    fun declineInvite(
+        @PathVariable inviteId: String,
+        @RequestHeader("Authorization") authorizationHeader: String?,
+    ): ResponseEntity<Any> =
+        runCatching {
+            val user = authSupport.requireUser(authorizationHeader)
+            ResponseEntity.ok(inviteService.declineInvite(user, inviteId) as Any)
+        }.getOrElse(::toInviteError)
+}
+
+private fun toInviteError(error: Throwable): ResponseEntity<Any> =
+    when (error) {
+        is UnauthorizedException -> ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(ErrorResponse(error.message ?: "Authentication required"))
+        is IllegalStateException ->
+            if (error.message?.contains("not found", ignoreCase = true) == true) {
+                ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse(error.message ?: "not found"))
+            } else {
+                ResponseEntity.badRequest().body(ErrorResponse(error.message ?: "invalid invite operation"))
+            }
+        else -> ResponseEntity.badRequest().body(ErrorResponse(error.message ?: "invalid invite operation"))
+    }

--- a/src/main/kotlin/at/aau/se2/skyjo/controller/LobbyInviteController.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/controller/LobbyInviteController.kt
@@ -1,8 +1,12 @@
 package at.aau.se2.skyjo.controller
 
+import at.aau.se2.skyjo.model.LobbyPlayerInfo
+import at.aau.se2.skyjo.model.LobbyUpdateMessage
 import at.aau.se2.skyjo.model.auth.ErrorResponse
+import at.aau.se2.skyjo.model.lobby.LobbyState
 import at.aau.se2.skyjo.model.social.LobbyInviteRequest
 import at.aau.se2.skyjo.service.LobbyInviteService
+import at.aau.se2.skyjo.service.LobbyService
 import at.aau.se2.skyjo.service.UnauthorizedException
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -17,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class LobbyInviteController(
     private val inviteService: LobbyInviteService,
+    private val lobbyService: LobbyService,
     private val authSupport: AuthSupport,
     private val messagingTemplate: SimpMessageSendingOperations,
 ) {
@@ -50,7 +55,13 @@ class LobbyInviteController(
     ): ResponseEntity<Any> =
         runCatching {
             val user = authSupport.requireUser(authorizationHeader)
-            ResponseEntity.ok(inviteService.acceptInvite(user, inviteId) as Any)
+            val accepted = inviteService.acceptInvite(user, inviteId)
+            lobbyService.getLobbyById(accepted.lobbyId)?.let { lobby ->
+                lobby.joinCode?.let { code ->
+                    messagingTemplate.convertAndSend("/topic/lobbies/$code", lobby.toUpdateMessage())
+                }
+            }
+            ResponseEntity.ok(accepted as Any)
         }.getOrElse(::toInviteError)
 
     @PostMapping("/api/lobbies/invites/{inviteId}/decline")
@@ -63,6 +74,14 @@ class LobbyInviteController(
             ResponseEntity.ok(inviteService.declineInvite(user, inviteId) as Any)
         }.getOrElse(::toInviteError)
 }
+
+private fun LobbyState.toUpdateMessage() = LobbyUpdateMessage(
+    lobbyId = lobbyId,
+    joinCode = joinCode,
+    players = players.map { LobbyPlayerInfo(nickname = it.nickname, isHost = it.isHost) },
+    status = status,
+    maxPlayers = maxPlayers,
+)
 
 private fun toInviteError(error: Throwable): ResponseEntity<Any> =
     when (error) {

--- a/src/main/kotlin/at/aau/se2/skyjo/controller/StatsController.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/controller/StatsController.kt
@@ -1,0 +1,45 @@
+package at.aau.se2.skyjo.controller
+
+import at.aau.se2.skyjo.model.auth.ErrorResponse
+import at.aau.se2.skyjo.service.StatsService
+import at.aau.se2.skyjo.service.UnauthorizedException
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class StatsController(
+    private val statsService: StatsService,
+    private val authSupport: AuthSupport,
+) {
+
+    @GetMapping("/api/stats/me")
+    fun myStats(
+        @RequestHeader("Authorization") authorizationHeader: String?,
+    ): ResponseEntity<Any> =
+        runCatching {
+            val user = authSupport.requireUser(authorizationHeader)
+            ResponseEntity.ok(statsService.getStats(user.userId) as Any)
+        }.getOrElse(::toStatsError)
+
+    @GetMapping("/api/leaderboard")
+    fun leaderboard(
+        @RequestParam(required = false) limit: Int?,
+    ): ResponseEntity<Any> =
+        ResponseEntity.ok(statsService.leaderboard(limit ?: DEFAULT_LEADERBOARD_LIMIT) as Any)
+
+    private companion object {
+        const val DEFAULT_LEADERBOARD_LIMIT = 50
+    }
+}
+
+private fun toStatsError(error: Throwable): ResponseEntity<Any> =
+    when (error) {
+        is UnauthorizedException -> ResponseEntity
+            .status(HttpStatus.UNAUTHORIZED)
+            .body(ErrorResponse(error.message ?: "Authentication required"))
+        else -> ResponseEntity.badRequest().body(ErrorResponse(error.message ?: "invalid stats operation"))
+    }

--- a/src/main/kotlin/at/aau/se2/skyjo/event/WebSocketEventListener.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/event/WebSocketEventListener.kt
@@ -47,6 +47,14 @@ class WebSocketEventListener(
             logger.info("Player disconnected and removed from lobby: $playerId")
             messagingTemplate.convertAndSend("/topic/lobby", updatedState.toUpdateMessage())
         }
+        val authenticatedLobby = runCatching { lobbyService.getCurrentLobbyForUser(playerId) }.getOrNull()
+        if (authenticatedLobby?.lobbyId != null) {
+            val updatedLobby = lobbyService.leaveLobby(playerId, authenticatedLobby.lobbyId)
+            logger.info("Authenticated player disconnected and removed from lobby: $playerId")
+            updatedLobby.joinCode?.let { code ->
+                messagingTemplate.convertAndSend("/topic/lobbies/$code", updatedLobby.toUpdateMessage())
+            }
+        }
     }
 }
 

--- a/src/main/kotlin/at/aau/se2/skyjo/event/WebSocketEventListener.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/event/WebSocketEventListener.kt
@@ -2,6 +2,7 @@ package at.aau.se2.skyjo.event
 
 import at.aau.se2.skyjo.model.LobbyPlayerInfo
 import at.aau.se2.skyjo.model.LobbyUpdateMessage
+import at.aau.se2.skyjo.model.GameUpdateMessage
 import at.aau.se2.skyjo.model.lobby.LobbyState
 import at.aau.se2.skyjo.service.AuthService
 import at.aau.se2.skyjo.service.GameService
@@ -28,7 +29,8 @@ class WebSocketEventListener(
         val userId = event.user?.name
         logger.info("New WebSocket connection: principal=$userId")
         if (userId != null) {
-            authService?.markUserConnected(userId)
+            val currentLobbyId = runCatching { lobbyService.getCurrentLobbyForUser(userId)?.lobbyId }.getOrNull()
+            authService?.markUserConnected(userId, currentLobbyId)
         }
     }
 
@@ -36,10 +38,9 @@ class WebSocketEventListener(
     fun handleWebSocketDisconnectListener(event: SessionDisconnectEvent) {
         val playerId = event.user?.name ?: return
         authService?.markUserDisconnected(playerId)
-        gameService?.markPlayerDisconnected(playerId)
-        val currentGameState = gameService?.getCurrentState()
-        if (currentGameState != null) {
-            messagingTemplate.convertAndSend("/topic/game", currentGameState)
+        val disconnectedGameState = gameService?.markPlayerDisconnected(playerId)
+        if (disconnectedGameState != null) {
+            messagingTemplate.convertAndSend(disconnectedGameState.topicPath(), disconnectedGameState)
         }
         if (lobbyService.isPlayerInLobby(playerId)) {
             val updatedState = lobbyService.leave(playerId)
@@ -56,3 +57,6 @@ private fun LobbyState.toUpdateMessage() = LobbyUpdateMessage(
     status = status,
     maxPlayers = maxPlayers,
 )
+
+private fun GameUpdateMessage.topicPath(): String =
+    gameId?.let { "/topic/games/$it" } ?: "/topic/game"

--- a/src/main/kotlin/at/aau/se2/skyjo/event/WebSocketEventListener.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/event/WebSocketEventListener.kt
@@ -50,6 +50,8 @@ class WebSocketEventListener(
 }
 
 private fun LobbyState.toUpdateMessage() = LobbyUpdateMessage(
+    lobbyId = lobbyId,
+    joinCode = joinCode,
     players = players.map { LobbyPlayerInfo(nickname = it.nickname, isHost = it.isHost) },
     status = status,
     maxPlayers = maxPlayers,

--- a/src/main/kotlin/at/aau/se2/skyjo/event/WebSocketEventListener.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/event/WebSocketEventListener.kt
@@ -3,6 +3,7 @@ package at.aau.se2.skyjo.event
 import at.aau.se2.skyjo.model.LobbyPlayerInfo
 import at.aau.se2.skyjo.model.LobbyUpdateMessage
 import at.aau.se2.skyjo.model.lobby.LobbyState
+import at.aau.se2.skyjo.service.AuthService
 import at.aau.se2.skyjo.service.GameService
 import at.aau.se2.skyjo.service.LobbyService
 import org.slf4j.LoggerFactory
@@ -17,18 +18,24 @@ class WebSocketEventListener(
     private val messagingTemplate: SimpMessageSendingOperations,
     private val lobbyService: LobbyService,
     private val gameService: GameService?,
+    private val authService: AuthService? = null,
 ) {
 
     private val logger = LoggerFactory.getLogger(WebSocketEventListener::class.java)
 
     @EventListener
     fun handleWebSocketConnectListener(event: SessionConnectedEvent) {
-        logger.info("New WebSocket connection: principal=${event.user?.name}")
+        val userId = event.user?.name
+        logger.info("New WebSocket connection: principal=$userId")
+        if (userId != null) {
+            authService?.markUserConnected(userId)
+        }
     }
 
     @EventListener
     fun handleWebSocketDisconnectListener(event: SessionDisconnectEvent) {
         val playerId = event.user?.name ?: return
+        authService?.markUserDisconnected(playerId)
         gameService?.markPlayerDisconnected(playerId)
         val currentGameState = gameService?.getCurrentState()
         if (currentGameState != null) {

--- a/src/main/kotlin/at/aau/se2/skyjo/model/GameUpdateMessage.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/model/GameUpdateMessage.kt
@@ -17,6 +17,7 @@ data class GameUpdateMessage(
     val totalScores: List<PlayerScoreDto>,
     val gameOver: Boolean,
     val gameId: String? = null,
+    val lobbyId: String? = null,
     val disconnectedPlayers: List<String> = emptyList(),
 )
 

--- a/src/main/kotlin/at/aau/se2/skyjo/model/LobbyUpdateMessage.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/model/LobbyUpdateMessage.kt
@@ -3,6 +3,8 @@ package at.aau.se2.skyjo.model
 import at.aau.se2.skyjo.model.lobby.LobbyStatus
 
 data class LobbyUpdateMessage(
+    val lobbyId: String? = null,
+    val joinCode: String? = null,
     val players: List<LobbyPlayerInfo>,
     val status: LobbyStatus,
     val maxPlayers: Int,

--- a/src/main/kotlin/at/aau/se2/skyjo/model/auth/AuthModels.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/model/auth/AuthModels.kt
@@ -1,0 +1,30 @@
+package at.aau.se2.skyjo.model.auth
+
+data class RegisterRequest(
+    val username: String,
+    val password: String,
+)
+
+data class LoginRequest(
+    val username: String,
+    val password: String,
+)
+
+data class AuthResponse(
+    val token: String,
+    val user: AuthUserDto,
+)
+
+data class AuthUserDto(
+    val userId: String,
+    val username: String,
+)
+
+data class WsTicketResponse(
+    val ticket: String,
+    val expiresAt: Long,
+)
+
+data class ErrorResponse(
+    val message: String,
+)

--- a/src/main/kotlin/at/aau/se2/skyjo/model/auth/AuthPrincipal.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/model/auth/AuthPrincipal.kt
@@ -1,0 +1,10 @@
+package at.aau.se2.skyjo.model.auth
+
+import java.security.Principal
+
+data class AuthPrincipal(
+    val userId: String,
+    val username: String,
+) : Principal {
+    override fun getName(): String = userId
+}

--- a/src/main/kotlin/at/aau/se2/skyjo/model/lobby/LobbyApiModels.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/model/lobby/LobbyApiModels.kt
@@ -1,0 +1,11 @@
+package at.aau.se2.skyjo.model.lobby
+
+import at.aau.se2.skyjo.model.LobbyPlayerInfo
+
+data class LobbySummaryResponse(
+    val lobbyId: String,
+    val joinCode: String,
+    val players: List<LobbyPlayerInfo>,
+    val status: LobbyStatus,
+    val maxPlayers: Int,
+)

--- a/src/main/kotlin/at/aau/se2/skyjo/model/lobby/LobbyPlayer.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/model/lobby/LobbyPlayer.kt
@@ -4,4 +4,5 @@ data class LobbyPlayer(
     val sessionId: String,
     val nickname: String,
     val isHost: Boolean,
+    val userId: String = sessionId,
 )

--- a/src/main/kotlin/at/aau/se2/skyjo/model/lobby/LobbyState.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/model/lobby/LobbyState.kt
@@ -1,6 +1,8 @@
 package at.aau.se2.skyjo.model.lobby
 
 data class LobbyState(
+    val lobbyId: String? = null,
+    val joinCode: String? = null,
     val players: List<LobbyPlayer> = emptyList(),
     val status: LobbyStatus = LobbyStatus.WAITING,
     val maxPlayers: Int = 6,

--- a/src/main/kotlin/at/aau/se2/skyjo/model/lobby/LobbyStatus.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/model/lobby/LobbyStatus.kt
@@ -3,4 +3,5 @@ package at.aau.se2.skyjo.model.lobby
 enum class LobbyStatus {
     WAITING,
     IN_GAME,
+    CLOSED,
 }

--- a/src/main/kotlin/at/aau/se2/skyjo/model/social/SocialModels.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/model/social/SocialModels.kt
@@ -43,3 +43,24 @@ data class FriendRequestsResponse(
 data class SendFriendRequestRequest(
     val toUserId: String,
 )
+
+enum class LobbyInviteStatus {
+    PENDING,
+    ACCEPTED,
+    DECLINED,
+}
+
+data class LobbyInviteRequest(
+    val toUserId: String,
+)
+
+data class LobbyInviteDto(
+    val inviteId: String,
+    val lobbyId: String,
+    val joinCode: String,
+    val from: SocialUserDto,
+    val to: SocialUserDto,
+    val status: LobbyInviteStatus,
+    val createdAt: Long,
+    val respondedAt: Long?,
+)

--- a/src/main/kotlin/at/aau/se2/skyjo/model/social/SocialModels.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/model/social/SocialModels.kt
@@ -1,0 +1,45 @@
+package at.aau.se2.skyjo.model.social
+
+enum class FriendRequestStatus {
+    PENDING,
+    ACCEPTED,
+    DECLINED,
+}
+
+enum class RelationshipStatus {
+    NONE,
+    FRIENDS,
+    INCOMING_REQUEST,
+    OUTGOING_REQUEST,
+}
+
+data class SocialUserDto(
+    val userId: String,
+    val username: String,
+    val relationshipStatus: RelationshipStatus = RelationshipStatus.NONE,
+)
+
+data class FriendDto(
+    val userId: String,
+    val username: String,
+    val online: Boolean,
+    val currentLobbyId: String?,
+)
+
+data class FriendRequestDto(
+    val requestId: String,
+    val from: SocialUserDto,
+    val to: SocialUserDto,
+    val status: FriendRequestStatus,
+    val createdAt: Long,
+    val respondedAt: Long?,
+)
+
+data class FriendRequestsResponse(
+    val incoming: List<FriendRequestDto>,
+    val outgoing: List<FriendRequestDto>,
+)
+
+data class SendFriendRequestRequest(
+    val toUserId: String,
+)

--- a/src/main/kotlin/at/aau/se2/skyjo/model/stats/StatsModels.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/model/stats/StatsModels.kt
@@ -1,0 +1,22 @@
+package at.aau.se2.skyjo.model.stats
+
+data class PlayerStatsDto(
+    val userId: String,
+    val username: String,
+    val gamesPlayed: Int,
+    val wins: Int,
+    val totalScore: Int,
+    val bestScore: Int?,
+    val averageScore: Double,
+)
+
+data class LeaderboardEntryDto(
+    val rank: Int,
+    val userId: String,
+    val username: String,
+    val averageScore: Double,
+    val wins: Int,
+    val gamesPlayed: Int,
+    val bestScore: Int?,
+    val totalScore: Int,
+)

--- a/src/main/kotlin/at/aau/se2/skyjo/persistence/AuthRepository.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/persistence/AuthRepository.kt
@@ -1,0 +1,288 @@
+package at.aau.se2.skyjo.persistence
+
+import jakarta.annotation.PostConstruct
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+
+data class AuthUserRecord(
+    val userId: String,
+    val username: String,
+    val passwordHash: String,
+    val createdAt: Long,
+    val lastSeen: Long,
+)
+
+data class AuthSessionRecord(
+    val tokenHash: String,
+    val userId: String,
+    val createdAt: Long,
+    val expiresAt: Long,
+    val revokedAt: Long?,
+    val lastSeen: Long,
+)
+
+data class WebSocketTicketRecord(
+    val ticketHash: String,
+    val userId: String,
+    val createdAt: Long,
+    val expiresAt: Long,
+    val consumedAt: Long?,
+)
+
+data class UserPresenceRecord(
+    val userId: String,
+    val connected: Boolean,
+    val currentLobbyId: String?,
+    val updatedAt: Long,
+)
+
+@Repository
+class AuthRepository(private val jdbc: JdbcTemplate) {
+
+    @PostConstruct
+    fun initSchema() {
+        jdbc.execute(
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                user_id TEXT PRIMARY KEY,
+                username TEXT NOT NULL COLLATE NOCASE UNIQUE,
+                password_hash TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                last_seen INTEGER NOT NULL
+            )
+            """.trimIndent()
+        )
+        jdbc.execute(
+            """
+            CREATE TABLE IF NOT EXISTS sessions (
+                token_hash TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                expires_at INTEGER NOT NULL,
+                revoked_at INTEGER,
+                last_seen INTEGER NOT NULL,
+                FOREIGN KEY(user_id) REFERENCES users(user_id)
+            )
+            """.trimIndent()
+        )
+        jdbc.execute(
+            """
+            CREATE TABLE IF NOT EXISTS websocket_tickets (
+                ticket_hash TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                expires_at INTEGER NOT NULL,
+                consumed_at INTEGER,
+                FOREIGN KEY(user_id) REFERENCES users(user_id)
+            )
+            """.trimIndent()
+        )
+        jdbc.execute(
+            """
+            CREATE TABLE IF NOT EXISTS user_presence (
+                user_id TEXT PRIMARY KEY,
+                connected INTEGER NOT NULL DEFAULT 0,
+                current_lobby_id TEXT,
+                updated_at INTEGER NOT NULL,
+                FOREIGN KEY(user_id) REFERENCES users(user_id)
+            )
+            """.trimIndent()
+        )
+    }
+
+    fun createUser(userId: String, username: String, passwordHash: String, now: Long) {
+        jdbc.update(
+            """
+            INSERT INTO users (user_id, username, password_hash, created_at, last_seen)
+            VALUES (?, ?, ?, ?, ?)
+            """.trimIndent(),
+            userId,
+            username,
+            passwordHash,
+            now,
+            now,
+        )
+    }
+
+    fun findUserByUsername(username: String): AuthUserRecord? =
+        jdbc.query(
+            """
+            SELECT user_id, username, password_hash, created_at, last_seen
+            FROM users
+            WHERE username = ? COLLATE NOCASE
+            """.trimIndent(),
+            { rs, _ ->
+                AuthUserRecord(
+                    userId = rs.getString("user_id"),
+                    username = rs.getString("username"),
+                    passwordHash = rs.getString("password_hash"),
+                    createdAt = rs.getLong("created_at"),
+                    lastSeen = rs.getLong("last_seen"),
+                )
+            },
+            username,
+        ).firstOrNull()
+
+    fun findUserById(userId: String): AuthUserRecord? =
+        jdbc.query(
+            """
+            SELECT user_id, username, password_hash, created_at, last_seen
+            FROM users
+            WHERE user_id = ?
+            """.trimIndent(),
+            { rs, _ ->
+                AuthUserRecord(
+                    userId = rs.getString("user_id"),
+                    username = rs.getString("username"),
+                    passwordHash = rs.getString("password_hash"),
+                    createdAt = rs.getLong("created_at"),
+                    lastSeen = rs.getLong("last_seen"),
+                )
+            },
+            userId,
+        ).firstOrNull()
+
+    fun createSession(tokenHash: String, userId: String, createdAt: Long, expiresAt: Long) {
+        jdbc.update(
+            """
+            INSERT INTO sessions (token_hash, user_id, created_at, expires_at, revoked_at, last_seen)
+            VALUES (?, ?, ?, ?, NULL, ?)
+            """.trimIndent(),
+            tokenHash,
+            userId,
+            createdAt,
+            expiresAt,
+            createdAt,
+        )
+    }
+
+    fun findActiveSession(tokenHash: String, now: Long): AuthSessionRecord? =
+        jdbc.query(
+            """
+            SELECT token_hash, user_id, created_at, expires_at, revoked_at, last_seen
+            FROM sessions
+            WHERE token_hash = ?
+              AND revoked_at IS NULL
+              AND expires_at > ?
+            """.trimIndent(),
+            { rs, _ -> rs.toSessionRecord() },
+            tokenHash,
+            now,
+        ).firstOrNull()
+
+    fun touchSession(tokenHash: String, now: Long) {
+        jdbc.update(
+            "UPDATE sessions SET last_seen = ? WHERE token_hash = ? AND revoked_at IS NULL",
+            now,
+            tokenHash,
+        )
+    }
+
+    fun revokeSession(tokenHash: String, now: Long) {
+        jdbc.update(
+            "UPDATE sessions SET revoked_at = ? WHERE token_hash = ? AND revoked_at IS NULL",
+            now,
+            tokenHash,
+        )
+    }
+
+    fun createWebSocketTicket(ticketHash: String, userId: String, createdAt: Long, expiresAt: Long) {
+        jdbc.update(
+            """
+            INSERT INTO websocket_tickets (ticket_hash, user_id, created_at, expires_at, consumed_at)
+            VALUES (?, ?, ?, ?, NULL)
+            """.trimIndent(),
+            ticketHash,
+            userId,
+            createdAt,
+            expiresAt,
+        )
+    }
+
+    fun consumeWebSocketTicket(ticketHash: String, now: Long): WebSocketTicketRecord? {
+        val ticket = jdbc.query(
+            """
+            SELECT ticket_hash, user_id, created_at, expires_at, consumed_at
+            FROM websocket_tickets
+            WHERE ticket_hash = ?
+              AND consumed_at IS NULL
+              AND expires_at > ?
+            """.trimIndent(),
+            { rs, _ ->
+                WebSocketTicketRecord(
+                    ticketHash = rs.getString("ticket_hash"),
+                    userId = rs.getString("user_id"),
+                    createdAt = rs.getLong("created_at"),
+                    expiresAt = rs.getLong("expires_at"),
+                    consumedAt = rs.getNullableLong("consumed_at"),
+                )
+            },
+            ticketHash,
+            now,
+        ).firstOrNull() ?: return null
+
+        val updated = jdbc.update(
+            """
+            UPDATE websocket_tickets
+            SET consumed_at = ?
+            WHERE ticket_hash = ?
+              AND consumed_at IS NULL
+              AND expires_at > ?
+            """.trimIndent(),
+            now,
+            ticketHash,
+            now,
+        )
+
+        return if (updated == 1) ticket.copy(consumedAt = now) else null
+    }
+
+    fun setPresence(userId: String, connected: Boolean, currentLobbyId: String?, now: Long) {
+        jdbc.update(
+            """
+            INSERT INTO user_presence (user_id, connected, current_lobby_id, updated_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(user_id) DO UPDATE SET
+                connected = excluded.connected,
+                current_lobby_id = excluded.current_lobby_id,
+                updated_at = excluded.updated_at
+            """.trimIndent(),
+            userId,
+            if (connected) 1 else 0,
+            currentLobbyId,
+            now,
+        )
+    }
+
+    fun getPresence(userId: String): UserPresenceRecord? =
+        jdbc.query(
+            """
+            SELECT user_id, connected, current_lobby_id, updated_at
+            FROM user_presence
+            WHERE user_id = ?
+            """.trimIndent(),
+            { rs, _ ->
+                UserPresenceRecord(
+                    userId = rs.getString("user_id"),
+                    connected = rs.getInt("connected") == 1,
+                    currentLobbyId = rs.getString("current_lobby_id"),
+                    updatedAt = rs.getLong("updated_at"),
+                )
+            },
+            userId,
+        ).firstOrNull()
+
+    private fun java.sql.ResultSet.toSessionRecord() = AuthSessionRecord(
+        tokenHash = getString("token_hash"),
+        userId = getString("user_id"),
+        createdAt = getLong("created_at"),
+        expiresAt = getLong("expires_at"),
+        revokedAt = getNullableLong("revoked_at"),
+        lastSeen = getLong("last_seen"),
+    )
+
+    private fun java.sql.ResultSet.getNullableLong(column: String): Long? {
+        val value = getLong(column)
+        return if (wasNull()) null else value
+    }
+}

--- a/src/main/kotlin/at/aau/se2/skyjo/persistence/FriendRepository.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/persistence/FriendRepository.kt
@@ -1,0 +1,220 @@
+package at.aau.se2.skyjo.persistence
+
+import at.aau.se2.skyjo.model.social.FriendRequestStatus
+import jakarta.annotation.PostConstruct
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+
+data class FriendUserRecord(
+    val userId: String,
+    val username: String,
+    val online: Boolean,
+    val currentLobbyId: String?,
+)
+
+data class FriendRequestRecord(
+    val requestId: String,
+    val fromUserId: String,
+    val fromUsername: String,
+    val toUserId: String,
+    val toUsername: String,
+    val status: FriendRequestStatus,
+    val createdAt: Long,
+    val respondedAt: Long?,
+)
+
+@Repository
+class FriendRepository(private val jdbc: JdbcTemplate) {
+
+    @PostConstruct
+    fun initSchema() {
+        jdbc.execute(
+            """
+            CREATE TABLE IF NOT EXISTS friend_requests (
+                request_id TEXT PRIMARY KEY,
+                from_user_id TEXT NOT NULL,
+                to_user_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                responded_at INTEGER,
+                UNIQUE(from_user_id, to_user_id),
+                FOREIGN KEY(from_user_id) REFERENCES users(user_id),
+                FOREIGN KEY(to_user_id) REFERENCES users(user_id)
+            )
+            """.trimIndent(),
+        )
+        jdbc.execute(
+            """
+            CREATE TABLE IF NOT EXISTS friendships (
+                user_id TEXT NOT NULL,
+                friend_user_id TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                PRIMARY KEY(user_id, friend_user_id),
+                FOREIGN KEY(user_id) REFERENCES users(user_id),
+                FOREIGN KEY(friend_user_id) REFERENCES users(user_id)
+            )
+            """.trimIndent(),
+        )
+    }
+
+    fun searchUsers(query: String, currentUserId: String, limit: Int): List<FriendUserRecord> =
+        jdbc.query(
+            """
+            SELECT u.user_id, u.username, COALESCE(p.connected, 0) AS connected, p.current_lobby_id
+            FROM users u
+            LEFT JOIN user_presence p ON p.user_id = u.user_id
+            WHERE u.user_id != ?
+              AND u.username LIKE ? COLLATE NOCASE
+            ORDER BY u.username COLLATE NOCASE ASC
+            LIMIT ?
+            """.trimIndent(),
+            ::toFriendUserRecord,
+            currentUserId,
+            "%${query.trim()}%",
+            limit,
+        )
+
+    fun createFriendRequest(requestId: String, fromUserId: String, toUserId: String, now: Long) {
+        jdbc.update(
+            """
+            INSERT INTO friend_requests (request_id, from_user_id, to_user_id, status, created_at, responded_at)
+            VALUES (?, ?, ?, ?, ?, NULL)
+            """.trimIndent(),
+            requestId,
+            fromUserId,
+            toUserId,
+            FriendRequestStatus.PENDING.name,
+            now,
+        )
+    }
+
+    fun findRequestById(requestId: String): FriendRequestRecord? =
+        jdbc.query(REQUEST_SELECT + " WHERE fr.request_id = ?", ::toFriendRequestRecord, requestId).firstOrNull()
+
+    fun findPendingRequest(fromUserId: String, toUserId: String): FriendRequestRecord? =
+        jdbc.query(
+            REQUEST_SELECT + """
+            WHERE fr.from_user_id = ?
+              AND fr.to_user_id = ?
+              AND fr.status = ?
+            """.trimIndent(),
+            ::toFriendRequestRecord,
+            fromUserId,
+            toUserId,
+            FriendRequestStatus.PENDING.name,
+        ).firstOrNull()
+
+    fun listIncomingRequests(userId: String): List<FriendRequestRecord> =
+        jdbc.query(
+            REQUEST_SELECT + """
+            WHERE fr.to_user_id = ?
+              AND fr.status = ?
+            ORDER BY fr.created_at DESC
+            """.trimIndent(),
+            ::toFriendRequestRecord,
+            userId,
+            FriendRequestStatus.PENDING.name,
+        )
+
+    fun listOutgoingRequests(userId: String): List<FriendRequestRecord> =
+        jdbc.query(
+            REQUEST_SELECT + """
+            WHERE fr.from_user_id = ?
+              AND fr.status = ?
+            ORDER BY fr.created_at DESC
+            """.trimIndent(),
+            ::toFriendRequestRecord,
+            userId,
+            FriendRequestStatus.PENDING.name,
+        )
+
+    fun updateRequestStatus(requestId: String, status: FriendRequestStatus, respondedAt: Long): FriendRequestRecord? {
+        jdbc.update(
+            "UPDATE friend_requests SET status = ?, responded_at = ? WHERE request_id = ?",
+            status.name,
+            respondedAt,
+            requestId,
+        )
+        return findRequestById(requestId)
+    }
+
+    fun createFriendship(userId: String, friendUserId: String, now: Long) {
+        jdbc.update(
+            """
+            INSERT OR IGNORE INTO friendships (user_id, friend_user_id, created_at)
+            VALUES (?, ?, ?)
+            """.trimIndent(),
+            userId,
+            friendUserId,
+            now,
+        )
+    }
+
+    fun areFriends(userId: String, friendUserId: String): Boolean =
+        jdbc.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM friendships
+            WHERE user_id = ?
+              AND friend_user_id = ?
+            """.trimIndent(),
+            Int::class.java,
+            userId,
+            friendUserId,
+        ) != 0
+
+    fun listFriends(userId: String): List<FriendUserRecord> =
+        jdbc.query(
+            """
+            SELECT u.user_id, u.username, COALESCE(p.connected, 0) AS connected, p.current_lobby_id
+            FROM friendships f
+            JOIN users u ON u.user_id = f.friend_user_id
+            LEFT JOIN user_presence p ON p.user_id = u.user_id
+            WHERE f.user_id = ?
+            ORDER BY u.username COLLATE NOCASE ASC
+            """.trimIndent(),
+            ::toFriendUserRecord,
+            userId,
+        )
+
+    private fun toFriendUserRecord(rs: java.sql.ResultSet, @Suppress("UNUSED_PARAMETER") rowNum: Int) =
+        FriendUserRecord(
+            userId = rs.getString("user_id"),
+            username = rs.getString("username"),
+            online = rs.getInt("connected") == 1,
+            currentLobbyId = rs.getString("current_lobby_id"),
+        )
+
+    private fun toFriendRequestRecord(rs: java.sql.ResultSet, @Suppress("UNUSED_PARAMETER") rowNum: Int) =
+        FriendRequestRecord(
+            requestId = rs.getString("request_id"),
+            fromUserId = rs.getString("from_user_id"),
+            fromUsername = rs.getString("from_username"),
+            toUserId = rs.getString("to_user_id"),
+            toUsername = rs.getString("to_username"),
+            status = FriendRequestStatus.valueOf(rs.getString("status")),
+            createdAt = rs.getLong("created_at"),
+            respondedAt = rs.getNullableLong("responded_at"),
+        )
+
+    private fun java.sql.ResultSet.getNullableLong(column: String): Long? {
+        val value = getLong(column)
+        return if (wasNull()) null else value
+    }
+
+    private companion object {
+        const val REQUEST_SELECT = """
+            SELECT fr.request_id,
+                   fr.from_user_id,
+                   from_user.username AS from_username,
+                   fr.to_user_id,
+                   to_user.username AS to_username,
+                   fr.status,
+                   fr.created_at,
+                   fr.responded_at
+            FROM friend_requests fr
+            JOIN users from_user ON from_user.user_id = fr.from_user_id
+            JOIN users to_user ON to_user.user_id = fr.to_user_id
+        """
+    }
+}

--- a/src/main/kotlin/at/aau/se2/skyjo/persistence/FriendRepository.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/persistence/FriendRepository.kt
@@ -79,6 +79,11 @@ class FriendRepository(private val jdbc: JdbcTemplate) {
             """
             INSERT INTO friend_requests (request_id, from_user_id, to_user_id, status, created_at, responded_at)
             VALUES (?, ?, ?, ?, ?, NULL)
+            ON CONFLICT(from_user_id, to_user_id) DO UPDATE SET
+                request_id = excluded.request_id,
+                status = excluded.status,
+                created_at = excluded.created_at,
+                responded_at = NULL
             """.trimIndent(),
             requestId,
             fromUserId,

--- a/src/main/kotlin/at/aau/se2/skyjo/persistence/GameRepository.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/persistence/GameRepository.kt
@@ -17,6 +17,12 @@ import jakarta.annotation.PostConstruct
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Repository
 
+data class PersistedGame(
+    val gameId: String,
+    val lobbyId: String?,
+    val state: GameState,
+)
+
 @Repository
 class GameRepository(private val jdbc: JdbcTemplate) {
 
@@ -53,12 +59,14 @@ class GameRepository(private val jdbc: JdbcTemplate) {
             """
             CREATE TABLE IF NOT EXISTS games (
                 game_id TEXT PRIMARY KEY,
+                lobby_id TEXT,
                 state_json TEXT NOT NULL,
                 phase TEXT NOT NULL,
                 updated_at INTEGER NOT NULL
             )
             """.trimIndent()
         )
+        runCatching { jdbc.execute("ALTER TABLE games ADD COLUMN lobby_id TEXT") }
         jdbc.execute(
             """
             CREATE TABLE IF NOT EXISTS player_sessions (
@@ -72,31 +80,43 @@ class GameRepository(private val jdbc: JdbcTemplate) {
     }
 
     fun saveGame(gameId: String, state: GameState) {
+        saveGame(gameId, lobbyId = null, state = state)
+    }
+
+    fun saveGame(gameId: String, lobbyId: String?, state: GameState) {
         val json = mapper.writeValueAsString(state)
         jdbc.update(
             """
-            INSERT INTO games (game_id, state_json, phase, updated_at)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO games (game_id, lobby_id, state_json, phase, updated_at)
+            VALUES (?, ?, ?, ?, ?)
             ON CONFLICT(game_id) DO UPDATE SET
+                lobby_id = excluded.lobby_id,
                 state_json = excluded.state_json,
                 phase = excluded.phase,
                 updated_at = excluded.updated_at
             """.trimIndent(),
-            gameId, json, state.phase.name, System.currentTimeMillis()
+            gameId, lobbyId, json, state.phase.name, System.currentTimeMillis()
         )
     }
 
-    fun loadActiveGame(): Pair<String, GameState>? {
+    fun loadActiveGame(): Pair<String, GameState>? =
+        loadActiveGames().firstOrNull()?.let { it.gameId to it.state }
+
+    fun loadActiveGames(): List<PersistedGame> {
         return try {
             jdbc.query(
-                "SELECT game_id, state_json FROM games WHERE phase != ? LIMIT 1",
-                { rs, _ -> rs.getString("game_id") to rs.getString("state_json") },
+                "SELECT game_id, lobby_id, state_json FROM games WHERE phase != ? ORDER BY updated_at ASC",
+                { rs, _ ->
+                    PersistedGame(
+                        gameId = rs.getString("game_id"),
+                        lobbyId = rs.getString("lobby_id"),
+                        state = mapper.readValue(rs.getString("state_json"), GameState::class.java),
+                    )
+                },
                 GamePhase.NOT_STARTED.name
-            ).firstOrNull()?.let { (gameId, json) ->
-                gameId to mapper.readValue(json, GameState::class.java)
-            }
+            )
         } catch (_: Exception) {
-            null
+            emptyList()
         }
     }
 

--- a/src/main/kotlin/at/aau/se2/skyjo/persistence/GameRepository.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/persistence/GameRepository.kt
@@ -62,11 +62,13 @@ class GameRepository(private val jdbc: JdbcTemplate) {
                 lobby_id TEXT,
                 state_json TEXT NOT NULL,
                 phase TEXT NOT NULL,
+                completed INTEGER NOT NULL DEFAULT 0,
                 updated_at INTEGER NOT NULL
             )
             """.trimIndent()
         )
         runCatching { jdbc.execute("ALTER TABLE games ADD COLUMN lobby_id TEXT") }
+        runCatching { jdbc.execute("ALTER TABLE games ADD COLUMN completed INTEGER NOT NULL DEFAULT 0") }
         jdbc.execute(
             """
             CREATE TABLE IF NOT EXISTS player_sessions (
@@ -79,23 +81,24 @@ class GameRepository(private val jdbc: JdbcTemplate) {
         )
     }
 
-    fun saveGame(gameId: String, state: GameState) {
-        saveGame(gameId, lobbyId = null, state = state)
+    fun saveGame(gameId: String, state: GameState, completed: Boolean = false) {
+        saveGame(gameId, lobbyId = null, state = state, completed = completed)
     }
 
-    fun saveGame(gameId: String, lobbyId: String?, state: GameState) {
+    fun saveGame(gameId: String, lobbyId: String?, state: GameState, completed: Boolean = false) {
         val json = mapper.writeValueAsString(state)
         jdbc.update(
             """
-            INSERT INTO games (game_id, lobby_id, state_json, phase, updated_at)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT INTO games (game_id, lobby_id, state_json, phase, completed, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
             ON CONFLICT(game_id) DO UPDATE SET
                 lobby_id = excluded.lobby_id,
                 state_json = excluded.state_json,
                 phase = excluded.phase,
+                completed = excluded.completed,
                 updated_at = excluded.updated_at
             """.trimIndent(),
-            gameId, lobbyId, json, state.phase.name, System.currentTimeMillis()
+            gameId, lobbyId, json, state.phase.name, if (completed) 1 else 0, System.currentTimeMillis()
         )
     }
 
@@ -105,7 +108,7 @@ class GameRepository(private val jdbc: JdbcTemplate) {
     fun loadActiveGames(): List<PersistedGame> {
         return try {
             jdbc.query(
-                "SELECT game_id, lobby_id, state_json FROM games WHERE phase != ? ORDER BY updated_at ASC",
+                "SELECT game_id, lobby_id, state_json FROM games WHERE completed = 0 AND phase != ? AND phase != ? ORDER BY updated_at ASC",
                 { rs, _ ->
                     PersistedGame(
                         gameId = rs.getString("game_id"),
@@ -113,7 +116,8 @@ class GameRepository(private val jdbc: JdbcTemplate) {
                         state = mapper.readValue(rs.getString("state_json"), GameState::class.java),
                     )
                 },
-                GamePhase.NOT_STARTED.name
+                GamePhase.NOT_STARTED.name,
+                GamePhase.ROUND_FINISHED.name
             )
         } catch (_: Exception) {
             emptyList()
@@ -141,12 +145,26 @@ class GameRepository(private val jdbc: JdbcTemplate) {
         )
     }
 
+    fun deletePlayerSessionsForGame(gameId: String) {
+        jdbc.update("DELETE FROM player_sessions WHERE game_id = ?", gameId)
+    }
+
     fun getPlayerGame(playerName: String): String? {
         return try {
             jdbc.query(
-                "SELECT game_id FROM player_sessions WHERE player_name = ?",
+                """
+                SELECT player_sessions.game_id
+                FROM player_sessions
+                JOIN games ON games.game_id = player_sessions.game_id
+                WHERE player_sessions.player_name = ?
+                  AND games.completed = 0
+                  AND games.phase != ?
+                  AND games.phase != ?
+                """.trimIndent(),
                 { rs, _ -> rs.getString("game_id") },
-                playerName
+                playerName,
+                GamePhase.NOT_STARTED.name,
+                GamePhase.ROUND_FINISHED.name
             ).firstOrNull()
         } catch (_: Exception) {
             null

--- a/src/main/kotlin/at/aau/se2/skyjo/persistence/LobbyInviteRepository.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/persistence/LobbyInviteRepository.kt
@@ -1,0 +1,144 @@
+package at.aau.se2.skyjo.persistence
+
+import at.aau.se2.skyjo.model.social.LobbyInviteStatus
+import jakarta.annotation.PostConstruct
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+
+data class LobbyInviteRecord(
+    val inviteId: String,
+    val lobbyId: String,
+    val joinCode: String,
+    val fromUserId: String,
+    val fromUsername: String,
+    val toUserId: String,
+    val toUsername: String,
+    val status: LobbyInviteStatus,
+    val createdAt: Long,
+    val respondedAt: Long?,
+)
+
+@Repository
+class LobbyInviteRepository(private val jdbc: JdbcTemplate) {
+
+    @PostConstruct
+    fun initSchema() {
+        jdbc.execute(
+            """
+            CREATE TABLE IF NOT EXISTS lobby_invites (
+                invite_id TEXT PRIMARY KEY,
+                lobby_id TEXT NOT NULL,
+                join_code TEXT NOT NULL,
+                from_user_id TEXT NOT NULL,
+                to_user_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at INTEGER NOT NULL,
+                responded_at INTEGER,
+                FOREIGN KEY(lobby_id) REFERENCES lobbies(lobby_id),
+                FOREIGN KEY(from_user_id) REFERENCES users(user_id),
+                FOREIGN KEY(to_user_id) REFERENCES users(user_id)
+            )
+            """.trimIndent(),
+        )
+    }
+
+    fun createInvite(
+        inviteId: String,
+        lobbyId: String,
+        joinCode: String,
+        fromUserId: String,
+        toUserId: String,
+        now: Long,
+    ) {
+        jdbc.update(
+            """
+            INSERT INTO lobby_invites (
+                invite_id, lobby_id, join_code, from_user_id, to_user_id, status, created_at, responded_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+            """.trimIndent(),
+            inviteId,
+            lobbyId,
+            joinCode,
+            fromUserId,
+            toUserId,
+            LobbyInviteStatus.PENDING.name,
+            now,
+        )
+    }
+
+    fun findInviteById(inviteId: String): LobbyInviteRecord? =
+        jdbc.query(INVITE_SELECT + " WHERE li.invite_id = ?", ::toRecord, inviteId).firstOrNull()
+
+    fun findPendingInvite(lobbyId: String, toUserId: String): LobbyInviteRecord? =
+        jdbc.query(
+            INVITE_SELECT + """
+            WHERE li.lobby_id = ?
+              AND li.to_user_id = ?
+              AND li.status = ?
+            """.trimIndent(),
+            ::toRecord,
+            lobbyId,
+            toUserId,
+            LobbyInviteStatus.PENDING.name,
+        ).firstOrNull()
+
+    fun listPendingInvitesForUser(userId: String): List<LobbyInviteRecord> =
+        jdbc.query(
+            INVITE_SELECT + """
+            WHERE li.to_user_id = ?
+              AND li.status = ?
+            ORDER BY li.created_at DESC
+            """.trimIndent(),
+            ::toRecord,
+            userId,
+            LobbyInviteStatus.PENDING.name,
+        )
+
+    fun updateInviteStatus(inviteId: String, status: LobbyInviteStatus, respondedAt: Long): LobbyInviteRecord? {
+        jdbc.update(
+            "UPDATE lobby_invites SET status = ?, responded_at = ? WHERE invite_id = ?",
+            status.name,
+            respondedAt,
+            inviteId,
+        )
+        return findInviteById(inviteId)
+    }
+
+    private fun toRecord(rs: java.sql.ResultSet, @Suppress("UNUSED_PARAMETER") rowNum: Int) =
+        LobbyInviteRecord(
+            inviteId = rs.getString("invite_id"),
+            lobbyId = rs.getString("lobby_id"),
+            joinCode = rs.getString("join_code"),
+            fromUserId = rs.getString("from_user_id"),
+            fromUsername = rs.getString("from_username"),
+            toUserId = rs.getString("to_user_id"),
+            toUsername = rs.getString("to_username"),
+            status = LobbyInviteStatus.valueOf(rs.getString("status")),
+            createdAt = rs.getLong("created_at"),
+            respondedAt = rs.getNullableLong("responded_at"),
+        )
+
+    private fun java.sql.ResultSet.getNullableLong(column: String): Long? {
+        val value = getLong(column)
+        return if (wasNull()) null else value
+    }
+
+    private companion object {
+        const val INVITE_SELECT = """
+            SELECT li.invite_id,
+                   li.lobby_id,
+                   li.join_code,
+                   li.from_user_id,
+                   from_user.username AS from_username,
+                   li.to_user_id,
+                   to_user.username AS to_username,
+                   li.status,
+                   li.created_at,
+                   li.responded_at
+            FROM lobby_invites li
+            JOIN users from_user ON from_user.user_id = li.from_user_id
+            JOIN users to_user ON to_user.user_id = li.to_user_id
+        """
+    }
+}

--- a/src/main/kotlin/at/aau/se2/skyjo/persistence/LobbyRepository.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/persistence/LobbyRepository.kt
@@ -1,0 +1,179 @@
+package at.aau.se2.skyjo.persistence
+
+import at.aau.se2.skyjo.model.lobby.LobbyStatus
+import jakarta.annotation.PostConstruct
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+
+data class LobbyRecord(
+    val lobbyId: String,
+    val joinCode: String,
+    val hostUserId: String,
+    val status: LobbyStatus,
+    val maxPlayers: Int,
+    val createdAt: Long,
+    val updatedAt: Long,
+)
+
+data class LobbyMemberRecord(
+    val lobbyId: String,
+    val userId: String,
+    val username: String,
+    val isHost: Boolean,
+    val joinedAt: Long,
+)
+
+@Repository
+class LobbyRepository(private val jdbc: JdbcTemplate) {
+
+    @PostConstruct
+    fun initSchema() {
+        jdbc.execute(
+            """
+            CREATE TABLE IF NOT EXISTS lobbies (
+                lobby_id TEXT PRIMARY KEY,
+                join_code TEXT NOT NULL COLLATE NOCASE UNIQUE,
+                host_user_id TEXT NOT NULL,
+                status TEXT NOT NULL,
+                max_players INTEGER NOT NULL,
+                created_at INTEGER NOT NULL,
+                updated_at INTEGER NOT NULL
+            )
+            """.trimIndent()
+        )
+        jdbc.execute(
+            """
+            CREATE TABLE IF NOT EXISTS lobby_members (
+                lobby_id TEXT NOT NULL,
+                user_id TEXT NOT NULL,
+                username TEXT NOT NULL,
+                is_host INTEGER NOT NULL,
+                joined_at INTEGER NOT NULL,
+                PRIMARY KEY(lobby_id, user_id),
+                FOREIGN KEY(lobby_id) REFERENCES lobbies(lobby_id)
+            )
+            """.trimIndent()
+        )
+    }
+
+    fun createLobby(lobbyId: String, joinCode: String, hostUserId: String, maxPlayers: Int, now: Long) {
+        jdbc.update(
+            """
+            INSERT INTO lobbies (lobby_id, join_code, host_user_id, status, max_players, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """.trimIndent(),
+            lobbyId,
+            joinCode,
+            hostUserId,
+            LobbyStatus.WAITING.name,
+            maxPlayers,
+            now,
+            now,
+        )
+    }
+
+    fun findLobbyByJoinCode(joinCode: String): LobbyRecord? =
+        jdbc.query(LOBBY_SELECT + " WHERE join_code = ? COLLATE NOCASE", ::toLobbyRecord, joinCode)
+            .firstOrNull()
+
+    fun findLobbyById(lobbyId: String): LobbyRecord? =
+        jdbc.query(LOBBY_SELECT + " WHERE lobby_id = ?", ::toLobbyRecord, lobbyId)
+            .firstOrNull()
+
+    fun findCurrentLobbyForUser(userId: String): LobbyRecord? =
+        jdbc.query(
+            """
+            $LOBBY_SELECT
+            WHERE lobby_id IN (
+                SELECT lobby_id FROM lobby_members WHERE user_id = ?
+            )
+              AND status IN (?, ?)
+            ORDER BY updated_at DESC
+            LIMIT 1
+            """.trimIndent(),
+            ::toLobbyRecord,
+            userId,
+            LobbyStatus.WAITING.name,
+            LobbyStatus.IN_GAME.name,
+        ).firstOrNull()
+
+    fun upsertMember(lobbyId: String, userId: String, username: String, isHost: Boolean, joinedAt: Long) {
+        jdbc.update(
+            """
+            INSERT INTO lobby_members (lobby_id, user_id, username, is_host, joined_at)
+            VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(lobby_id, user_id) DO UPDATE SET
+                username = excluded.username,
+                is_host = excluded.is_host,
+                joined_at = excluded.joined_at
+            """.trimIndent(),
+            lobbyId,
+            userId,
+            username,
+            if (isHost) 1 else 0,
+            joinedAt,
+        )
+    }
+
+    fun listMembers(lobbyId: String): List<LobbyMemberRecord> =
+        jdbc.query(
+            """
+            SELECT lobby_id, user_id, username, is_host, joined_at
+            FROM lobby_members
+            WHERE lobby_id = ?
+            ORDER BY joined_at ASC
+            """.trimIndent(),
+            { rs, _ ->
+                LobbyMemberRecord(
+                    lobbyId = rs.getString("lobby_id"),
+                    userId = rs.getString("user_id"),
+                    username = rs.getString("username"),
+                    isHost = rs.getInt("is_host") == 1,
+                    joinedAt = rs.getLong("joined_at"),
+                )
+            },
+            lobbyId,
+        )
+
+    fun removeMember(lobbyId: String, userId: String) {
+        jdbc.update("DELETE FROM lobby_members WHERE lobby_id = ? AND user_id = ?", lobbyId, userId)
+    }
+
+    fun setHost(lobbyId: String, userId: String, isHost: Boolean) {
+        jdbc.update(
+            "UPDATE lobby_members SET is_host = ? WHERE lobby_id = ? AND user_id = ?",
+            if (isHost) 1 else 0,
+            lobbyId,
+            userId,
+        )
+        if (isHost) {
+            jdbc.update("UPDATE lobbies SET host_user_id = ? WHERE lobby_id = ?", userId, lobbyId)
+        }
+    }
+
+    fun updateLobbyStatus(lobbyId: String, status: LobbyStatus, now: Long) {
+        jdbc.update(
+            "UPDATE lobbies SET status = ?, updated_at = ? WHERE lobby_id = ?",
+            status.name,
+            now,
+            lobbyId,
+        )
+    }
+
+    private fun toLobbyRecord(rs: java.sql.ResultSet, @Suppress("UNUSED_PARAMETER") rowNum: Int) = LobbyRecord(
+        lobbyId = rs.getString("lobby_id"),
+        joinCode = rs.getString("join_code"),
+        hostUserId = rs.getString("host_user_id"),
+        status = LobbyStatus.valueOf(rs.getString("status")),
+        maxPlayers = rs.getInt("max_players"),
+        createdAt = rs.getLong("created_at"),
+        updatedAt = rs.getLong("updated_at"),
+    )
+
+    private companion object {
+        const val LOBBY_SELECT = """
+            SELECT lobby_id, join_code, host_user_id, status, max_players, created_at, updated_at
+            FROM lobbies
+        """
+    }
+}

--- a/src/main/kotlin/at/aau/se2/skyjo/persistence/StatsRepository.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/persistence/StatsRepository.kt
@@ -1,0 +1,115 @@
+package at.aau.se2.skyjo.persistence
+
+import jakarta.annotation.PostConstruct
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+
+data class PlayerStatsRecord(
+    val userId: String,
+    val username: String,
+    val gamesPlayed: Int,
+    val wins: Int,
+    val totalScore: Int,
+    val bestScore: Int?,
+    val averageScore: Double,
+    val updatedAt: Long,
+)
+
+@Repository
+class StatsRepository(private val jdbc: JdbcTemplate) {
+
+    @PostConstruct
+    fun initSchema() {
+        jdbc.execute(
+            """
+            CREATE TABLE IF NOT EXISTS player_stats (
+                user_id TEXT PRIMARY KEY,
+                games_played INTEGER NOT NULL DEFAULT 0,
+                wins INTEGER NOT NULL DEFAULT 0,
+                total_score INTEGER NOT NULL DEFAULT 0,
+                best_score INTEGER,
+                updated_at INTEGER NOT NULL,
+                FOREIGN KEY(user_id) REFERENCES users(user_id)
+            )
+            """.trimIndent(),
+        )
+    }
+
+    fun recordResult(userId: String, totalScore: Int, won: Boolean, now: Long) {
+        jdbc.update(
+            """
+            INSERT INTO player_stats (user_id, games_played, wins, total_score, best_score, updated_at)
+            VALUES (?, 1, ?, ?, ?, ?)
+            ON CONFLICT(user_id) DO UPDATE SET
+                games_played = player_stats.games_played + 1,
+                wins = player_stats.wins + excluded.wins,
+                total_score = player_stats.total_score + excluded.total_score,
+                best_score = CASE
+                    WHEN player_stats.best_score IS NULL OR excluded.best_score < player_stats.best_score
+                    THEN excluded.best_score
+                    ELSE player_stats.best_score
+                END,
+                updated_at = excluded.updated_at
+            """.trimIndent(),
+            userId,
+            if (won) 1 else 0,
+            totalScore,
+            totalScore,
+            now,
+        )
+    }
+
+    fun findStats(userId: String): PlayerStatsRecord? =
+        jdbc.query(
+            STATS_SELECT + " WHERE ps.user_id = ?",
+            ::toRecord,
+            userId,
+        ).firstOrNull()
+
+    fun leaderboard(limit: Int): List<PlayerStatsRecord> =
+        jdbc.query(
+            """
+            $STATS_SELECT
+            WHERE ps.games_played > 0
+            ORDER BY average_score ASC,
+                     ps.wins DESC,
+                     ps.games_played DESC,
+                     u.username COLLATE NOCASE ASC
+            LIMIT ?
+            """.trimIndent(),
+            ::toRecord,
+            limit,
+        )
+
+    private fun toRecord(rs: java.sql.ResultSet, @Suppress("UNUSED_PARAMETER") rowNum: Int) =
+        PlayerStatsRecord(
+            userId = rs.getString("user_id"),
+            username = rs.getString("username"),
+            gamesPlayed = rs.getInt("games_played"),
+            wins = rs.getInt("wins"),
+            totalScore = rs.getInt("total_score"),
+            bestScore = rs.getNullableInt("best_score"),
+            averageScore = rs.getDouble("average_score"),
+            updatedAt = rs.getLong("updated_at"),
+        )
+
+    private fun java.sql.ResultSet.getNullableInt(column: String): Int? {
+        val value = getInt(column)
+        return if (wasNull()) null else value
+    }
+
+    private companion object {
+        const val STATS_SELECT = """
+            SELECT ps.user_id,
+                   u.username,
+                   ps.games_played,
+                   ps.wins,
+                   ps.total_score,
+                   ps.best_score,
+                   CAST(ps.total_score AS REAL) / ps.games_played AS average_score,
+                   ps.updated_at
+            FROM player_stats ps
+            JOIN users u ON u.user_id = ps.user_id
+        """
+    }
+}

--- a/src/main/kotlin/at/aau/se2/skyjo/service/AuthService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/AuthService.kt
@@ -1,0 +1,167 @@
+package at.aau.se2.skyjo.service
+
+import at.aau.se2.skyjo.model.auth.AuthResponse
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.auth.WsTicketResponse
+import at.aau.se2.skyjo.persistence.AuthRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.dao.DataAccessException
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+import java.util.UUID
+
+interface SecureTokenGenerator {
+    fun generateToken(): String
+}
+
+class RandomSecureTokenGenerator : SecureTokenGenerator {
+    private val secureRandom = SecureRandom()
+
+    override fun generateToken(): String {
+        val bytes = ByteArray(32)
+        secureRandom.nextBytes(bytes)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+}
+
+class InvalidAuthInputException(message: String) : IllegalArgumentException(message)
+
+class DuplicateUsernameException : IllegalStateException("Username is already taken")
+
+class InvalidCredentialsException : IllegalArgumentException("Invalid username or password")
+
+class UnauthorizedException : IllegalArgumentException("Authentication required")
+
+@Service
+class AuthService @Autowired constructor(
+    private val repository: AuthRepository,
+) {
+
+    private var passwordEncoder: PasswordEncoder = BCryptPasswordEncoder()
+    private var nowProvider: () -> Long = { System.currentTimeMillis() }
+    private var tokenGenerator: SecureTokenGenerator = RandomSecureTokenGenerator()
+
+    internal constructor(
+        repository: AuthRepository,
+        passwordEncoder: PasswordEncoder,
+        nowProvider: () -> Long,
+        tokenGenerator: SecureTokenGenerator,
+    ) : this(repository) {
+        this.passwordEncoder = passwordEncoder
+        this.nowProvider = nowProvider
+        this.tokenGenerator = tokenGenerator
+    }
+
+    fun register(username: String, password: String): AuthResponse {
+        val normalizedUsername = validateUsername(username)
+        validatePassword(password)
+
+        if (repository.findUserByUsername(normalizedUsername) != null) {
+            throw DuplicateUsernameException()
+        }
+
+        val now = nowProvider()
+        val userId = UUID.randomUUID().toString()
+        val passwordHash = passwordEncoder.encode(password)
+
+        try {
+            repository.createUser(userId, normalizedUsername, passwordHash, now)
+        } catch (e: DataAccessException) {
+            if (repository.findUserByUsername(normalizedUsername) != null) {
+                throw DuplicateUsernameException()
+            }
+            throw e
+        }
+
+        return createAuthResponse(userId, normalizedUsername, now)
+    }
+
+    fun login(username: String, password: String): AuthResponse {
+        val user = repository.findUserByUsername(username.trim())
+            ?: throw InvalidCredentialsException()
+
+        if (!passwordEncoder.matches(password, user.passwordHash)) {
+            throw InvalidCredentialsException()
+        }
+
+        return createAuthResponse(user.userId, user.username, nowProvider())
+    }
+
+    fun requireUser(token: String): AuthUserDto {
+        val now = nowProvider()
+        val session = repository.findActiveSession(hashSecret(token), now)
+            ?: throw UnauthorizedException()
+        repository.touchSession(session.tokenHash, now)
+        val user = repository.findUserById(session.userId)
+            ?: throw UnauthorizedException()
+        return AuthUserDto(userId = user.userId, username = user.username)
+    }
+
+    fun logout(token: String) {
+        repository.revokeSession(hashSecret(token), nowProvider())
+    }
+
+    fun createWebSocketTicket(token: String): WsTicketResponse {
+        val user = requireUser(token)
+        val now = nowProvider()
+        val ticket = tokenGenerator.generateToken()
+        val expiresAt = now + WEBSOCKET_TICKET_TTL_MILLIS
+        repository.createWebSocketTicket(
+            ticketHash = hashSecret(ticket),
+            userId = user.userId,
+            createdAt = now,
+            expiresAt = expiresAt,
+        )
+        return WsTicketResponse(ticket = ticket, expiresAt = expiresAt)
+    }
+
+    fun consumeWebSocketTicket(ticket: String): AuthUserDto? {
+        val consumed = repository.consumeWebSocketTicket(hashSecret(ticket), nowProvider())
+            ?: return null
+        val user = repository.findUserById(consumed.userId) ?: return null
+        return AuthUserDto(userId = user.userId, username = user.username)
+    }
+
+    private fun createAuthResponse(userId: String, username: String, now: Long): AuthResponse {
+        val token = tokenGenerator.generateToken()
+        repository.createSession(
+            tokenHash = hashSecret(token),
+            userId = userId,
+            createdAt = now,
+            expiresAt = now + SESSION_TTL_MILLIS,
+        )
+        return AuthResponse(
+            token = token,
+            user = AuthUserDto(userId = userId, username = username),
+        )
+    }
+
+    private fun validateUsername(username: String): String {
+        val trimmed = username.trim()
+        if (!USERNAME_PATTERN.matches(trimmed)) {
+            throw InvalidAuthInputException("Username must be 3-20 characters and contain only letters, numbers, and underscores")
+        }
+        return trimmed
+    }
+
+    private fun validatePassword(password: String) {
+        if (password.length < 8) {
+            throw InvalidAuthInputException("Password must be at least 8 characters")
+        }
+    }
+
+    private fun hashSecret(value: String): String {
+        val digest = MessageDigest.getInstance("SHA-256").digest(value.toByteArray(Charsets.UTF_8))
+        return digest.joinToString(separator = "") { "%02x".format(it) }
+    }
+
+    companion object {
+        const val SESSION_TTL_MILLIS: Long = 30L * 24L * 60L * 60L * 1_000L
+        const val WEBSOCKET_TICKET_TTL_MILLIS: Long = 60L * 1_000L
+        private val USERNAME_PATTERN = Regex("^[A-Za-z0-9_]{3,20}$")
+    }
+}

--- a/src/main/kotlin/at/aau/se2/skyjo/service/AuthService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/AuthService.kt
@@ -126,6 +126,24 @@ class AuthService @Autowired constructor(
         return AuthUserDto(userId = user.userId, username = user.username)
     }
 
+    fun markUserConnected(userId: String, currentLobbyId: String? = null) {
+        repository.setPresence(
+            userId = userId,
+            connected = true,
+            currentLobbyId = currentLobbyId,
+            now = nowProvider(),
+        )
+    }
+
+    fun markUserDisconnected(userId: String) {
+        repository.setPresence(
+            userId = userId,
+            connected = false,
+            currentLobbyId = null,
+            now = nowProvider(),
+        )
+    }
+
     private fun createAuthResponse(userId: String, username: String, now: Long): AuthResponse {
         val token = tokenGenerator.generateToken()
         repository.createSession(

--- a/src/main/kotlin/at/aau/se2/skyjo/service/FriendService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/FriendService.kt
@@ -1,0 +1,154 @@
+package at.aau.se2.skyjo.service
+
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.social.FriendDto
+import at.aau.se2.skyjo.model.social.FriendRequestDto
+import at.aau.se2.skyjo.model.social.FriendRequestsResponse
+import at.aau.se2.skyjo.model.social.FriendRequestStatus
+import at.aau.se2.skyjo.model.social.RelationshipStatus
+import at.aau.se2.skyjo.model.social.SocialUserDto
+import at.aau.se2.skyjo.persistence.AuthRepository
+import at.aau.se2.skyjo.persistence.FriendRepository
+import at.aau.se2.skyjo.persistence.FriendRequestRecord
+import at.aau.se2.skyjo.persistence.FriendUserRecord
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.dao.DataAccessException
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+interface FriendRequestIdGenerator {
+    fun generateId(): String
+}
+
+class RandomFriendRequestIdGenerator : FriendRequestIdGenerator {
+    override fun generateId(): String = UUID.randomUUID().toString()
+}
+
+@Service
+class FriendService @Autowired constructor(
+    private val repository: FriendRepository,
+    private val authRepository: AuthRepository,
+) {
+
+    private var requestIdGenerator: FriendRequestIdGenerator = RandomFriendRequestIdGenerator()
+    private var nowProvider: () -> Long = { System.currentTimeMillis() }
+
+    internal constructor(
+        repository: FriendRepository,
+        authRepository: AuthRepository,
+        requestIdGenerator: FriendRequestIdGenerator,
+        nowProvider: () -> Long,
+    ) : this(repository, authRepository) {
+        this.requestIdGenerator = requestIdGenerator
+        this.nowProvider = nowProvider
+    }
+
+    fun searchUsers(user: AuthUserDto, query: String): List<SocialUserDto> {
+        val normalizedQuery = query.trim()
+        if (normalizedQuery.isBlank()) {
+            return emptyList()
+        }
+
+        return repository.searchUsers(normalizedQuery, user.userId, SEARCH_LIMIT).map { record ->
+            SocialUserDto(
+                userId = record.userId,
+                username = record.username,
+                relationshipStatus = relationshipStatus(user.userId, record.userId),
+            )
+        }
+    }
+
+    fun listFriends(user: AuthUserDto): List<FriendDto> =
+        repository.listFriends(user.userId).map { it.toFriendDto() }
+
+    fun listFriendRequests(user: AuthUserDto): FriendRequestsResponse =
+        FriendRequestsResponse(
+            incoming = repository.listIncomingRequests(user.userId).map { it.toDto() },
+            outgoing = repository.listOutgoingRequests(user.userId).map { it.toDto() },
+        )
+
+    fun sendFriendRequest(from: AuthUserDto, toUserId: String): FriendRequestDto {
+        if (from.userId == toUserId) {
+            error("cannot send friend request to yourself")
+        }
+        authRepository.findUserById(toUserId) ?: error("user not found")
+        if (repository.areFriends(from.userId, toUserId)) {
+            error("users are already friends")
+        }
+        if (repository.findPendingRequest(from.userId, toUserId) != null ||
+            repository.findPendingRequest(toUserId, from.userId) != null
+        ) {
+            error("friend request already exists")
+        }
+
+        val requestId = requestIdGenerator.generateId()
+        try {
+            repository.createFriendRequest(requestId, from.userId, toUserId, nowProvider())
+        } catch (e: DataAccessException) {
+            if (repository.findPendingRequest(from.userId, toUserId) != null) {
+                error("friend request already exists")
+            }
+            throw e
+        }
+        return repository.findRequestById(requestId)?.toDto() ?: error("friend request not found")
+    }
+
+    fun acceptFriendRequest(user: AuthUserDto, requestId: String): FriendRequestDto {
+        val request = repository.findRequestById(requestId) ?: error("friend request not found")
+        if (request.toUserId != user.userId) {
+            throw UnauthorizedException()
+        }
+        if (request.status != FriendRequestStatus.PENDING) {
+            error("friend request is not pending")
+        }
+
+        val now = nowProvider()
+        val accepted = repository.updateRequestStatus(requestId, FriendRequestStatus.ACCEPTED, now)
+            ?: error("friend request not found")
+        repository.createFriendship(accepted.fromUserId, accepted.toUserId, now)
+        repository.createFriendship(accepted.toUserId, accepted.fromUserId, now)
+        return accepted.toDto()
+    }
+
+    fun declineFriendRequest(user: AuthUserDto, requestId: String): FriendRequestDto {
+        val request = repository.findRequestById(requestId) ?: error("friend request not found")
+        if (request.toUserId != user.userId) {
+            throw UnauthorizedException()
+        }
+        if (request.status != FriendRequestStatus.PENDING) {
+            error("friend request is not pending")
+        }
+        return repository.updateRequestStatus(requestId, FriendRequestStatus.DECLINED, nowProvider())?.toDto()
+            ?: error("friend request not found")
+    }
+
+    private fun relationshipStatus(currentUserId: String, targetUserId: String): RelationshipStatus =
+        when {
+            repository.areFriends(currentUserId, targetUserId) -> RelationshipStatus.FRIENDS
+            repository.findPendingRequest(currentUserId, targetUserId) != null -> RelationshipStatus.OUTGOING_REQUEST
+            repository.findPendingRequest(targetUserId, currentUserId) != null -> RelationshipStatus.INCOMING_REQUEST
+            else -> RelationshipStatus.NONE
+        }
+
+    private fun FriendUserRecord.toFriendDto() =
+        FriendDto(
+            userId = userId,
+            username = username,
+            online = online,
+            currentLobbyId = currentLobbyId,
+        )
+
+    private fun FriendRequestRecord.toDto() =
+        FriendRequestDto(
+            requestId = requestId,
+            from = SocialUserDto(fromUserId, fromUsername),
+            to = SocialUserDto(toUserId, toUsername),
+            status = status,
+            createdAt = createdAt,
+            respondedAt = respondedAt,
+        )
+
+    private companion object {
+        const val SEARCH_LIMIT = 20
+    }
+}

--- a/src/main/kotlin/at/aau/se2/skyjo/service/FriendService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/FriendService.kt
@@ -63,8 +63,8 @@ class FriendService @Autowired constructor(
 
     fun listFriendRequests(user: AuthUserDto): FriendRequestsResponse =
         FriendRequestsResponse(
-            incoming = repository.listIncomingRequests(user.userId).map { it.toDto() },
-            outgoing = repository.listOutgoingRequests(user.userId).map { it.toDto() },
+            incoming = repository.listIncomingRequests(user.userId).map { it.toDto(user.userId) },
+            outgoing = repository.listOutgoingRequests(user.userId).map { it.toDto(user.userId) },
         )
 
     fun sendFriendRequest(from: AuthUserDto, toUserId: String): FriendRequestDto {
@@ -90,7 +90,7 @@ class FriendService @Autowired constructor(
             }
             throw e
         }
-        return repository.findRequestById(requestId)?.toDto() ?: error("friend request not found")
+        return repository.findRequestById(requestId)?.toDto(from.userId) ?: error("friend request not found")
     }
 
     fun acceptFriendRequest(user: AuthUserDto, requestId: String): FriendRequestDto {
@@ -107,7 +107,7 @@ class FriendService @Autowired constructor(
             ?: error("friend request not found")
         repository.createFriendship(accepted.fromUserId, accepted.toUserId, now)
         repository.createFriendship(accepted.toUserId, accepted.fromUserId, now)
-        return accepted.toDto()
+        return accepted.toDto(user.userId)
     }
 
     fun declineFriendRequest(user: AuthUserDto, requestId: String): FriendRequestDto {
@@ -118,7 +118,7 @@ class FriendService @Autowired constructor(
         if (request.status != FriendRequestStatus.PENDING) {
             error("friend request is not pending")
         }
-        return repository.updateRequestStatus(requestId, FriendRequestStatus.DECLINED, nowProvider())?.toDto()
+        return repository.updateRequestStatus(requestId, FriendRequestStatus.DECLINED, nowProvider())?.toDto(user.userId)
             ?: error("friend request not found")
     }
 
@@ -138,11 +138,11 @@ class FriendService @Autowired constructor(
             currentLobbyId = currentLobbyId,
         )
 
-    private fun FriendRequestRecord.toDto() =
+    private fun FriendRequestRecord.toDto(viewerId: String) =
         FriendRequestDto(
             requestId = requestId,
-            from = SocialUserDto(fromUserId, fromUsername),
-            to = SocialUserDto(toUserId, toUsername),
+            from = SocialUserDto(fromUserId, fromUsername, relationshipStatus(viewerId, fromUserId)),
+            to = SocialUserDto(toUserId, toUsername, relationshipStatus(viewerId, toUserId)),
             status = status,
             createdAt = createdAt,
             respondedAt = respondedAt,

--- a/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
@@ -32,15 +32,17 @@ import at.aau.se2.skyjo.model.PlayActionCardMessageResult
 import at.aau.se2.skyjo.model.SlotType
 import at.aau.se2.skyjo.model.lobby.LobbyPlayer
 import at.aau.se2.skyjo.persistence.GameRepository
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import java.util.UUID
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
 @Service
-class GameService(
+class GameService @Autowired constructor(
     private val engine: SkyjoEngine,
     private val gameRepository: GameRepository?,
+    private val statsService: StatsService?,
 ) {
 
     private data class ManagedGame(
@@ -58,6 +60,7 @@ class GameService(
     private val lock = ReentrantLock()
     private val games = mutableMapOf<String, ManagedGame>()
     private val playerGameIndex = mutableMapOf<String, String>()
+    private val recordedStatsGameIds = mutableSetOf<String>()
 
     private var currentGameId: String? = null
     private var gameState: GameState? = null
@@ -67,6 +70,8 @@ class GameService(
     private var playerInfo: Map<String, String> = emptyMap()
     private val sessionAliases: MutableMap<String, String> = mutableMapOf()
     private val disconnectedNicknames: MutableSet<String> = mutableSetOf()
+
+    constructor(engine: SkyjoEngine, gameRepository: GameRepository?) : this(engine, gameRepository, null)
 
     init {
         gameRepository?.loadActiveGames()?.forEach { persisted ->
@@ -293,6 +298,7 @@ class GameService(
 
         if (isGameOver) {
             gameRepository?.saveGame(game.gameId, game.lobbyId, finishedState)
+            recordFinalStatsOnce(game)
             syncLegacyIfCurrent(game)
             return toUpdateMessage(game, finishedState, gameOver = true)
         }
@@ -387,6 +393,12 @@ class GameService(
     private fun syncLegacyIfCurrent(game: ManagedGame) {
         if (game.gameId == currentGameId) {
             syncLegacyFrom(game)
+        }
+    }
+
+    private fun recordFinalStatsOnce(game: ManagedGame) {
+        if (recordedStatsGameIds.add(game.gameId)) {
+            statsService?.recordGameResult(game.gameId, game.totalScores)
         }
     }
 

--- a/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
@@ -95,13 +95,15 @@ class GameService @Autowired constructor(
 
     fun getActiveGameId(): String? = lock.withLock { currentGameId }
 
-    fun markPlayerDisconnected(principalId: String) = lock.withLock {
-        val game = findManagedGameForPlayer(principalId) ?: return@withLock
+    fun markPlayerDisconnected(principalId: String): GameUpdateMessage? = lock.withLock {
+        val game = findManagedGameForPlayer(principalId) ?: return@withLock null
+        syncManagedFromLegacyIfCurrent(game)
         val playerId = game.sessionAliases[principalId] ?: principalId
-        val nickname = game.playerInfo[playerId] ?: return@withLock
+        val nickname = game.playerInfo[playerId] ?: return@withLock null
         game.disconnectedNicknames.add(nickname)
         gameRepository?.markDisconnected(playerId)
         syncLegacyIfCurrent(game)
+        toUpdateMessage(game, game.gameState, gameOver = false)
     }
 
     fun addSessionAlias(newSessionId: String, nickname: String): Boolean = lock.withLock {
@@ -115,6 +117,28 @@ class GameService @Autowired constructor(
         game.disconnectedNicknames.remove(nickname)
         syncLegacyIfCurrent(game)
         true
+    }
+
+    fun reconnectPlayer(principalId: String, nickname: String, gameId: String): GameUpdateMessage? = lock.withLock {
+        val game = games[gameId]
+            ?: ensureLegacyManagedGame()?.takeIf { it.gameId == gameId }
+            ?: return@withLock null
+        syncManagedFromLegacyIfCurrent(game)
+
+        val playerId = when {
+            principalId in game.playerInfo -> principalId
+            else -> game.playerInfo.entries.firstOrNull { it.value == nickname }?.key
+        } ?: return@withLock null
+
+        if (principalId != playerId) {
+            game.sessionAliases[principalId] = playerId
+        }
+        playerGameIndex[principalId] = game.gameId
+        playerGameIndex[playerId] = game.gameId
+        game.disconnectedNicknames.remove(game.playerInfo[playerId])
+        gameRepository?.savePlayerSession(playerId, game.gameId, connected = true)
+        syncLegacyIfCurrent(game)
+        toUpdateMessage(game, game.gameState, gameOver = false)
     }
 
     fun startGame(players: List<LobbyPlayer>, gameConfig: GameConfig = GameConfig()): GameUpdateMessage = lock.withLock {

--- a/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
@@ -1,13 +1,14 @@
 package at.aau.se2.skyjo.service
 
+import at.aau.se2.skyjo.game.error.InvalidMoveException
 import at.aau.se2.skyjo.game.model.ActionCardParameters
+import at.aau.se2.skyjo.game.model.ActionCardResult
 import at.aau.se2.skyjo.game.model.BoardLayout
 import at.aau.se2.skyjo.game.model.BoardPosition
 import at.aau.se2.skyjo.game.model.BoardSlot
 import at.aau.se2.skyjo.game.model.DrawSource
 import at.aau.se2.skyjo.game.model.GamePhase
 import at.aau.se2.skyjo.game.model.GameState
-import at.aau.se2.skyjo.game.model.ActionCardResult
 import at.aau.se2.skyjo.game.model.PlayActionCardCommand
 import at.aau.se2.skyjo.game.model.SkyjoCard
 import at.aau.se2.skyjo.game.model.displayLabel
@@ -35,7 +36,6 @@ import org.springframework.stereotype.Service
 import java.util.UUID
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
-import at.aau.se2.skyjo.game.error.InvalidMoveException
 
 @Service
 class GameService(
@@ -43,7 +43,21 @@ class GameService(
     private val gameRepository: GameRepository?,
 ) {
 
+    private data class ManagedGame(
+        val gameId: String,
+        val lobbyId: String?,
+        var gameState: GameState,
+        var config: GameConfig,
+        var roundNumber: Int,
+        var totalScores: Map<String, Int>,
+        var playerInfo: Map<String, String>,
+        val sessionAliases: MutableMap<String, String> = mutableMapOf(),
+        val disconnectedNicknames: MutableSet<String> = mutableSetOf(),
+    )
+
     private val lock = ReentrantLock()
+    private val games = mutableMapOf<String, ManagedGame>()
+    private val playerGameIndex = mutableMapOf<String, String>()
 
     private var currentGameId: String? = null
     private var gameState: GameState? = null
@@ -54,50 +68,64 @@ class GameService(
     private val sessionAliases: MutableMap<String, String> = mutableMapOf()
     private val disconnectedNicknames: MutableSet<String> = mutableSetOf()
 
-    fun getActiveGameId(): String? = currentGameId
-
-    fun markPlayerDisconnected(principalId: String) {
-        val nickname = playerInfo[principalId] ?: return
-        disconnectedNicknames.add(nickname)
-        gameRepository?.markDisconnected(nickname)
-    }
-
-    fun addSessionAlias(newSessionId: String, nickname: String): Boolean = lock.withLock {
-        val oldPlayerId = playerInfo.entries.firstOrNull { it.value == nickname }?.key ?: return@withLock false
-        sessionAliases[newSessionId] = oldPlayerId
-        disconnectedNicknames.remove(nickname)
-        true
-    }
-
     init {
-        gameRepository?.loadActiveGame()?.let { (id, state) ->
-            currentGameId = id
-            gameState = state
+        gameRepository?.loadActiveGames()?.forEach { persisted ->
+            val playerIds = persisted.state.players.map { it.id }
+            val managedGame = ManagedGame(
+                gameId = persisted.gameId,
+                lobbyId = persisted.lobbyId,
+                gameState = persisted.state,
+                config = GameConfig(),
+                roundNumber = 1,
+                totalScores = playerIds.associateWith { 0 },
+                playerInfo = playerIds.associateWith { it },
+            )
+            games[managedGame.gameId] = managedGame
+            playerIds.forEach { playerGameIndex[it] = managedGame.gameId }
+            if (currentGameId == null) {
+                syncLegacyFrom(managedGame)
+            }
         }
     }
 
-    fun startGame(players: List<LobbyPlayer>, gameConfig: GameConfig = GameConfig()): GameUpdateMessage = lock.withLock {
-        val playerIds = players.map { it.sessionId }
-        val initialReveals = playerIds.associateWith { setOf(BoardPosition(0, 0), BoardPosition(0, 1)) }
+    fun getActiveGameId(): String? = lock.withLock { currentGameId }
 
-        sessionAliases.clear()
-        disconnectedNicknames.clear()
-        config = gameConfig
-        roundNumber = 1
-        totalScores = playerIds.associateWith { 0 }
-        playerInfo = players.associate { it.sessionId to it.nickname }
-
-        val newState = engine.startGame(playerIds, initialReveals)
-        gameState = newState
-        currentGameId = UUID.randomUUID().toString()
-        gameRepository?.saveGame(currentGameId!!, newState)
-        players.forEach { gameRepository?.savePlayerSession(it.nickname, currentGameId!!, connected = true) }
-        toUpdateMessage(newState, gameOver = false)
+    fun markPlayerDisconnected(principalId: String) = lock.withLock {
+        val game = findManagedGameForPlayer(principalId) ?: return@withLock
+        val playerId = game.sessionAliases[principalId] ?: principalId
+        val nickname = game.playerInfo[playerId] ?: return@withLock
+        game.disconnectedNicknames.add(nickname)
+        gameRepository?.markDisconnected(playerId)
+        syncLegacyIfCurrent(game)
     }
 
+    fun addSessionAlias(newSessionId: String, nickname: String): Boolean = lock.withLock {
+        val game = games.values.firstOrNull { managed ->
+            managed.playerInfo.values.any { it == nickname }
+        } ?: return@withLock false
+        val oldPlayerId = game.playerInfo.entries.first { it.value == nickname }.key
+
+        game.sessionAliases[newSessionId] = oldPlayerId
+        playerGameIndex[newSessionId] = game.gameId
+        game.disconnectedNicknames.remove(nickname)
+        syncLegacyIfCurrent(game)
+        true
+    }
+
+    fun startGame(players: List<LobbyPlayer>, gameConfig: GameConfig = GameConfig()): GameUpdateMessage = lock.withLock {
+        startGameInternal(lobbyId = null, players = players, gameConfig = gameConfig)
+    }
+
+    fun startGame(lobbyId: String, players: List<LobbyPlayer>, gameConfig: GameConfig = GameConfig()): GameUpdateMessage =
+        lock.withLock {
+            startGameInternal(lobbyId = lobbyId, players = players, gameConfig = gameConfig)
+        }
+
     fun processAction(playerId: String, action: GameActionMessage): GameUpdateMessage = lock.withLock {
-        val state = gameState ?: error("game has not started yet")
-        val resolvedPlayerId = sessionAliases[playerId] ?: playerId
+        val game = findManagedGameForPlayer(playerId) ?: error("game has not started yet")
+        syncManagedFromLegacyIfCurrent(game)
+        val state = game.gameState
+        val resolvedPlayerId = game.sessionAliases[playerId] ?: playerId
 
         if (state.currentPlayerId != resolvedPlayerId) {
             error("not your turn (current player: ${state.currentPlayerId})")
@@ -154,19 +182,22 @@ class GameService(
             }
         }
 
-        gameState = updatedState
-        currentGameId?.let { gameRepository?.saveGame(it, updatedState) }
+        game.gameState = updatedState
+        gameRepository?.saveGame(game.gameId, game.lobbyId, updatedState)
+        syncLegacyIfCurrent(game)
 
         if (updatedState.phase == GamePhase.ROUND_FINISHED) {
-            return@withLock handleRoundFinished(updatedState)
+            return@withLock handleRoundFinished(game, updatedState)
         }
 
-        toUpdateMessage(updatedState, gameOver = false)
+        toUpdateMessage(game, updatedState, gameOver = false)
     }
 
     fun playActionCard(playerId: String, command: PlayActionCardCommand): PlayActionCardMessageResult = lock.withLock {
-        val state = gameState ?: error("game has not started yet")
-        val resolvedPlayerId = sessionAliases[playerId] ?: playerId
+        val game = findManagedGameForPlayer(playerId) ?: error("game has not started yet")
+        syncManagedFromLegacyIfCurrent(game)
+        val state = game.gameState
+        val resolvedPlayerId = game.sessionAliases[playerId] ?: playerId
 
         if (state.currentPlayerId != resolvedPlayerId) {
             error("not your turn (current player: ${state.currentPlayerId})")
@@ -178,13 +209,14 @@ class GameService(
             ?: emptyMap()
         val updatedState = updatedStateWithResult.copy(actionCardResult = null)
 
-        gameState = updatedState
-        currentGameId?.let { gameRepository?.saveGame(it, updatedState) }
+        game.gameState = updatedState
+        gameRepository?.saveGame(game.gameId, game.lobbyId, updatedState)
+        syncLegacyIfCurrent(game)
 
         val update = if (updatedState.phase == GamePhase.ROUND_FINISHED) {
-            handleRoundFinished(updatedState)
+            handleRoundFinished(game, updatedState)
         } else {
-            toUpdateMessage(updatedState, gameOver = false)
+            toUpdateMessage(game, updatedState, gameOver = false)
         }
 
         PlayActionCardMessageResult(
@@ -194,32 +226,171 @@ class GameService(
     }
 
     fun getCurrentState(): GameUpdateMessage? = lock.withLock {
-        gameState?.let { toUpdateMessage(it, gameOver = false) }
+        currentManagedGame()?.let { game ->
+            syncManagedFromLegacyIfCurrent(game)
+            toUpdateMessage(game, game.gameState, gameOver = false)
+        }
+            ?: gameState?.let { toUpdateMessageFromLegacy(it, gameOver = false) }
+    }
+
+    fun getCurrentState(playerId: String): GameUpdateMessage? = lock.withLock {
+        findManagedGameForPlayer(playerId)?.let { game ->
+            syncManagedFromLegacyIfCurrent(game)
+            toUpdateMessage(game, game.gameState, gameOver = false)
+        }
     }
 
     internal fun handleRoundFinished(finishedState: GameState): GameUpdateMessage {
+        val game = currentManagedGame() ?: error("game has not started yet")
+        syncManagedFromLegacyIfCurrent(game)
+        return handleRoundFinished(game, finishedState)
+    }
+
+    private fun startGameInternal(
+        lobbyId: String?,
+        players: List<LobbyPlayer>,
+        gameConfig: GameConfig,
+    ): GameUpdateMessage {
+        val playerIds = players.map { it.userId }
+        val initialReveals = playerIds.associateWith { setOf(BoardPosition(0, 0), BoardPosition(0, 1)) }
+        val newState = engine.startGame(playerIds, initialReveals)
+        val newGameId = UUID.randomUUID().toString()
+        val managedGame = ManagedGame(
+            gameId = newGameId,
+            lobbyId = lobbyId,
+            gameState = newState,
+            config = gameConfig,
+            roundNumber = 1,
+            totalScores = playerIds.associateWith { 0 },
+            playerInfo = players.associate { it.userId to it.nickname },
+        )
+
+        players.forEach { player ->
+            if (player.sessionId != player.userId) {
+                managedGame.sessionAliases[player.sessionId] = player.userId
+                playerGameIndex[player.sessionId] = managedGame.gameId
+            }
+            playerGameIndex[player.userId] = managedGame.gameId
+            gameRepository?.savePlayerSession(player.userId, managedGame.gameId, connected = true)
+        }
+
+        games[managedGame.gameId] = managedGame
+        gameRepository?.saveGame(managedGame.gameId, managedGame.lobbyId, newState)
+        syncLegacyFrom(managedGame)
+        return toUpdateMessage(managedGame, newState, gameOver = false)
+    }
+
+    private fun handleRoundFinished(game: ManagedGame, finishedState: GameState): GameUpdateMessage {
         val roundResult = finishedState.roundResult!!
+        game.gameState = finishedState
 
         roundResult.scores.forEach { score ->
-            totalScores = totalScores + (score.playerId to ((totalScores[score.playerId] ?: 0) + score.finalScore))
+            game.totalScores = game.totalScores + (score.playerId to ((game.totalScores[score.playerId] ?: 0) + score.finalScore))
         }
 
-        val isGameOver = roundNumber >= config.maxRounds || totalScores.values.any { it >= config.targetScore }
+        val isGameOver = game.roundNumber >= game.config.maxRounds ||
+            game.totalScores.values.any { it >= game.config.targetScore }
 
         if (isGameOver) {
-            return toUpdateMessage(finishedState, gameOver = true)
+            gameRepository?.saveGame(game.gameId, game.lobbyId, finishedState)
+            syncLegacyIfCurrent(game)
+            return toUpdateMessage(game, finishedState, gameOver = true)
         }
 
-        roundNumber++
+        game.roundNumber++
         val playerIds = finishedState.players.map { it.id }
         val initialReveals = playerIds.associateWith { setOf(BoardPosition(0, 0), BoardPosition(0, 1)) }
         val newRoundState = engine.startGame(playerIds, initialReveals)
-        gameState = newRoundState
-        currentGameId?.let { gameRepository?.saveGame(it, newRoundState) }
-        return toUpdateMessage(newRoundState, gameOver = false)
+        game.gameState = newRoundState
+        gameRepository?.saveGame(game.gameId, game.lobbyId, newRoundState)
+        syncLegacyIfCurrent(game)
+        return toUpdateMessage(game, newRoundState, gameOver = false)
     }
 
-    private fun toUpdateMessage(state: GameState, gameOver: Boolean): GameUpdateMessage {
+    private fun currentManagedGame(): ManagedGame? =
+        currentGameId?.let(games::get) ?: ensureLegacyManagedGame()
+
+    private fun findManagedGameForPlayer(principalId: String): ManagedGame? {
+        playerGameIndex[principalId]?.let { gameId ->
+            games[gameId]?.let { return it }
+        }
+
+        val matched = games.values.firstOrNull { game ->
+            principalId in game.playerInfo || principalId in game.sessionAliases
+        }
+        if (matched != null) {
+            playerGameIndex[principalId] = matched.gameId
+            return matched
+        }
+
+        val legacyGame = ensureLegacyManagedGame() ?: return null
+        val resolvedPlayerId = legacyGame.sessionAliases[principalId] ?: principalId
+        return if (resolvedPlayerId in legacyGame.playerInfo) {
+            playerGameIndex[principalId] = legacyGame.gameId
+            legacyGame
+        } else {
+            null
+        }
+    }
+
+    private fun ensureLegacyManagedGame(): ManagedGame? {
+        val state = gameState ?: return null
+        val legacyGameId = currentGameId ?: "legacy-game"
+        currentGameId = legacyGameId
+        val playerIds = state.players.map { it.id }
+        val managedGame = games.getOrPut(legacyGameId) {
+            ManagedGame(
+                gameId = legacyGameId,
+                lobbyId = null,
+                gameState = state,
+                config = config,
+                roundNumber = roundNumber.takeIf { it > 0 } ?: 1,
+                totalScores = totalScores.ifEmpty { playerIds.associateWith { 0 } },
+                playerInfo = playerInfo.ifEmpty { playerIds.associateWith { it } },
+                sessionAliases = sessionAliases.toMutableMap(),
+                disconnectedNicknames = disconnectedNicknames.toMutableSet(),
+            )
+        }
+        playerIds.forEach { playerGameIndex.putIfAbsent(it, managedGame.gameId) }
+        syncManagedFromLegacyIfCurrent(managedGame)
+        return managedGame
+    }
+
+    private fun syncLegacyFrom(game: ManagedGame) {
+        currentGameId = game.gameId
+        gameState = game.gameState
+        config = game.config
+        roundNumber = game.roundNumber
+        totalScores = game.totalScores
+        playerInfo = game.playerInfo
+        sessionAliases.clear()
+        sessionAliases.putAll(game.sessionAliases)
+        disconnectedNicknames.clear()
+        disconnectedNicknames.addAll(game.disconnectedNicknames)
+    }
+
+    private fun syncManagedFromLegacyIfCurrent(game: ManagedGame) {
+        if (game.gameId != currentGameId) {
+            return
+        }
+        game.gameState = gameState ?: game.gameState
+        game.config = config
+        game.roundNumber = roundNumber
+        game.totalScores = totalScores.ifEmpty { game.totalScores }
+        game.playerInfo = playerInfo.ifEmpty { game.playerInfo }
+        game.sessionAliases.clear()
+        game.sessionAliases.putAll(sessionAliases)
+        game.disconnectedNicknames.clear()
+        game.disconnectedNicknames.addAll(disconnectedNicknames)
+    }
+
+    private fun syncLegacyIfCurrent(game: ManagedGame) {
+        if (game.gameId == currentGameId) {
+            syncLegacyFrom(game)
+        }
+    }
+
+    private fun toUpdateMessage(game: ManagedGame, state: GameState, gameOver: Boolean): GameUpdateMessage {
         val players = state.players.map { playerState ->
             val rows = (0 until BoardLayout.ROWS).map { row ->
                 (0 until BoardLayout.COLUMNS).map { col ->
@@ -236,16 +407,16 @@ class GameService(
             }
             PlayerBoardDto(
                 playerId = playerState.id,
-                nickname = playerInfo[playerState.id] ?: playerState.id,
+                nickname = game.playerInfo[playerState.id] ?: playerState.id,
                 board = rows,
                 actionCards = playerState.actionCards.map(::toActionCardDto),
             )
         }
 
-        val scores = totalScores.map { (playerId, score) ->
+        val scores = game.totalScores.map { (playerId, score) ->
             PlayerScoreDto(
                 playerId = playerId,
-                nickname = playerInfo[playerId] ?: playerId,
+                nickname = game.playerInfo[playerId] ?: playerId,
                 totalScore = score,
             )
         }
@@ -259,12 +430,28 @@ class GameService(
             visibleActionCards = state.visibleActionCards.map(::toActionCardDto),
             actionDrawPileCount = state.actionDrawPile.size,
             roundResult = state.roundResult,
-            roundNumber = roundNumber,
+            roundNumber = game.roundNumber,
             totalScores = scores,
             gameOver = gameOver,
-            gameId = currentGameId,
-            disconnectedPlayers = disconnectedNicknames.toList(),
+            gameId = game.gameId,
+            lobbyId = game.lobbyId,
+            disconnectedPlayers = game.disconnectedNicknames.toList(),
         )
+    }
+
+    private fun toUpdateMessageFromLegacy(state: GameState, gameOver: Boolean): GameUpdateMessage {
+        val legacyGame = ManagedGame(
+            gameId = currentGameId ?: "legacy-game",
+            lobbyId = null,
+            gameState = state,
+            config = config,
+            roundNumber = roundNumber,
+            totalScores = totalScores,
+            playerInfo = playerInfo,
+            sessionAliases = sessionAliases.toMutableMap(),
+            disconnectedNicknames = disconnectedNicknames.toMutableSet(),
+        )
+        return toUpdateMessage(legacyGame, state, gameOver)
     }
 
     private fun toCardDto(card: SkyjoCard): CardDto =

--- a/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
@@ -53,6 +53,7 @@ class GameService @Autowired constructor(
         var roundNumber: Int,
         var totalScores: Map<String, Int>,
         var playerInfo: Map<String, String>,
+        var completed: Boolean = false,
         val sessionAliases: MutableMap<String, String> = mutableMapOf(),
         val disconnectedNicknames: MutableSet<String> = mutableSetOf(),
     )
@@ -93,7 +94,9 @@ class GameService @Autowired constructor(
         }
     }
 
-    fun getActiveGameId(): String? = lock.withLock { currentGameId }
+    fun getActiveGameId(): String? = lock.withLock {
+        currentGameId?.takeUnless { games[it]?.completed == true }
+    }
 
     fun markPlayerDisconnected(principalId: String): GameUpdateMessage? = lock.withLock {
         val game = findManagedGameForPlayer(principalId) ?: return@withLock null
@@ -103,12 +106,12 @@ class GameService @Autowired constructor(
         game.disconnectedNicknames.add(nickname)
         gameRepository?.markDisconnected(playerId)
         syncLegacyIfCurrent(game)
-        toUpdateMessage(game, game.gameState, gameOver = false)
+        toUpdateMessage(game, game.gameState, gameOver = game.completed)
     }
 
     fun addSessionAlias(newSessionId: String, nickname: String): Boolean = lock.withLock {
         val game = games.values.firstOrNull { managed ->
-            managed.playerInfo.values.any { it == nickname }
+            !managed.completed && managed.playerInfo.values.any { it == nickname }
         } ?: return@withLock false
         val oldPlayerId = game.playerInfo.entries.first { it.value == nickname }.key
 
@@ -120,8 +123,8 @@ class GameService @Autowired constructor(
     }
 
     fun reconnectPlayer(principalId: String, nickname: String, gameId: String): GameUpdateMessage? = lock.withLock {
-        val game = games[gameId]
-            ?: ensureLegacyManagedGame()?.takeIf { it.gameId == gameId }
+        val game = games[gameId]?.takeUnless { it.completed }
+            ?: ensureLegacyManagedGame()?.takeIf { it.gameId == gameId && !it.completed }
             ?: return@withLock null
         syncManagedFromLegacyIfCurrent(game)
 
@@ -138,7 +141,7 @@ class GameService @Autowired constructor(
         game.disconnectedNicknames.remove(game.playerInfo[playerId])
         gameRepository?.savePlayerSession(playerId, game.gameId, connected = true)
         syncLegacyIfCurrent(game)
-        toUpdateMessage(game, game.gameState, gameOver = false)
+        toUpdateMessage(game, game.gameState, gameOver = game.completed)
     }
 
     fun startGame(players: List<LobbyPlayer>, gameConfig: GameConfig = GameConfig()): GameUpdateMessage = lock.withLock {
@@ -257,7 +260,7 @@ class GameService @Autowired constructor(
     fun getCurrentState(): GameUpdateMessage? = lock.withLock {
         currentManagedGame()?.let { game ->
             syncManagedFromLegacyIfCurrent(game)
-            toUpdateMessage(game, game.gameState, gameOver = false)
+            toUpdateMessage(game, game.gameState, gameOver = game.completed)
         }
             ?: gameState?.let { toUpdateMessageFromLegacy(it, gameOver = false) }
     }
@@ -265,7 +268,7 @@ class GameService @Autowired constructor(
     fun getCurrentState(playerId: String): GameUpdateMessage? = lock.withLock {
         findManagedGameForPlayer(playerId)?.let { game ->
             syncManagedFromLegacyIfCurrent(game)
-            toUpdateMessage(game, game.gameState, gameOver = false)
+            toUpdateMessage(game, game.gameState, gameOver = game.completed)
         }
     }
 
@@ -310,6 +313,9 @@ class GameService @Autowired constructor(
     }
 
     private fun handleRoundFinished(game: ManagedGame, finishedState: GameState): GameUpdateMessage {
+        if (game.completed) {
+            return toUpdateMessage(game, game.gameState, gameOver = true)
+        }
         val roundResult = finishedState.roundResult!!
         game.gameState = finishedState
 
@@ -321,7 +327,10 @@ class GameService @Autowired constructor(
             game.totalScores.values.any { it >= game.config.targetScore }
 
         if (isGameOver) {
-            gameRepository?.saveGame(game.gameId, game.lobbyId, finishedState)
+            game.completed = true
+            gameRepository?.saveGame(game.gameId, game.lobbyId, finishedState, completed = true)
+            gameRepository?.deletePlayerSessionsForGame(game.gameId)
+            removePlayerIndexes(game)
             recordFinalStatsOnce(game)
             syncLegacyIfCurrent(game)
             return toUpdateMessage(game, finishedState, gameOver = true)
@@ -342,18 +351,18 @@ class GameService @Autowired constructor(
 
     private fun findManagedGameForPlayer(principalId: String): ManagedGame? {
         playerGameIndex[principalId]?.let { gameId ->
-            games[gameId]?.let { return it }
+            games[gameId]?.takeUnless { it.completed }?.let { return it }
         }
 
         val matched = games.values.firstOrNull { game ->
-            principalId in game.playerInfo || principalId in game.sessionAliases
+            !game.completed && (principalId in game.playerInfo || principalId in game.sessionAliases)
         }
         if (matched != null) {
             playerGameIndex[principalId] = matched.gameId
             return matched
         }
 
-        val legacyGame = ensureLegacyManagedGame() ?: return null
+        val legacyGame = ensureLegacyManagedGame()?.takeUnless { it.completed } ?: return null
         val resolvedPlayerId = legacyGame.sessionAliases[principalId] ?: principalId
         return if (resolvedPlayerId in legacyGame.playerInfo) {
             playerGameIndex[principalId] = legacyGame.gameId
@@ -424,6 +433,10 @@ class GameService @Autowired constructor(
         if (recordedStatsGameIds.add(game.gameId)) {
             statsService?.recordGameResult(game.gameId, game.totalScores)
         }
+    }
+
+    private fun removePlayerIndexes(game: ManagedGame) {
+        (game.playerInfo.keys + game.sessionAliases.keys).forEach { playerGameIndex.remove(it) }
     }
 
     private fun toUpdateMessage(game: ManagedGame, state: GameState, gameOver: Boolean): GameUpdateMessage {

--- a/src/main/kotlin/at/aau/se2/skyjo/service/LobbyInviteService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/LobbyInviteService.kt
@@ -1,0 +1,120 @@
+package at.aau.se2.skyjo.service
+
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.lobby.LobbyStatus
+import at.aau.se2.skyjo.model.social.LobbyInviteDto
+import at.aau.se2.skyjo.model.social.LobbyInviteStatus
+import at.aau.se2.skyjo.model.social.SocialUserDto
+import at.aau.se2.skyjo.persistence.AuthRepository
+import at.aau.se2.skyjo.persistence.FriendRepository
+import at.aau.se2.skyjo.persistence.LobbyInviteRecord
+import at.aau.se2.skyjo.persistence.LobbyInviteRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+import java.util.UUID
+
+interface LobbyInviteIdGenerator {
+    fun generateId(): String
+}
+
+class RandomLobbyInviteIdGenerator : LobbyInviteIdGenerator {
+    override fun generateId(): String = UUID.randomUUID().toString()
+}
+
+@Service
+class LobbyInviteService @Autowired constructor(
+    private val repository: LobbyInviteRepository,
+    private val authRepository: AuthRepository,
+    private val friendRepository: FriendRepository,
+    private val lobbyService: LobbyService,
+) {
+
+    private var inviteIdGenerator: LobbyInviteIdGenerator = RandomLobbyInviteIdGenerator()
+    private var nowProvider: () -> Long = { System.currentTimeMillis() }
+
+    internal constructor(
+        repository: LobbyInviteRepository,
+        authRepository: AuthRepository,
+        friendRepository: FriendRepository,
+        lobbyService: LobbyService,
+        inviteIdGenerator: LobbyInviteIdGenerator,
+        nowProvider: () -> Long,
+    ) : this(repository, authRepository, friendRepository, lobbyService) {
+        this.inviteIdGenerator = inviteIdGenerator
+        this.nowProvider = nowProvider
+    }
+
+    fun createInvite(from: AuthUserDto, lobbyId: String, toUserId: String): LobbyInviteDto {
+        if (from.userId == toUserId) {
+            error("cannot invite yourself")
+        }
+        authRepository.findUserById(toUserId) ?: error("user not found")
+        if (!friendRepository.areFriends(from.userId, toUserId)) {
+            error("only friends can be invited")
+        }
+        val lobby = lobbyService.getLobbyById(lobbyId) ?: error("lobby not found")
+        if (lobby.status != LobbyStatus.WAITING) {
+            error("cannot invite to a lobby that is not waiting")
+        }
+        if (lobby.players.none { it.userId == from.userId }) {
+            error("only a lobby member can invite")
+        }
+        if (repository.findPendingInvite(lobbyId, toUserId) != null) {
+            error("lobby invite already exists")
+        }
+
+        repository.createInvite(
+            inviteId = inviteIdGenerator.generateId(),
+            lobbyId = lobbyId,
+            joinCode = requireNotNull(lobby.joinCode) { "join code is missing" },
+            fromUserId = from.userId,
+            toUserId = toUserId,
+            now = nowProvider(),
+        )
+        return repository.findPendingInvite(lobbyId, toUserId)?.toDto() ?: error("lobby invite not found")
+    }
+
+    fun listInvites(user: AuthUserDto): List<LobbyInviteDto> =
+        repository.listPendingInvitesForUser(user.userId).map { it.toDto() }
+
+    fun acceptInvite(user: AuthUserDto, inviteId: String): LobbyInviteDto {
+        val invite = requirePendingInviteForUser(user, inviteId)
+        val lobby = lobbyService.getLobbyById(invite.lobbyId) ?: error("lobby not found")
+        if (lobby.status != LobbyStatus.WAITING) {
+            error("cannot accept invite for a lobby that is not waiting")
+        }
+
+        lobbyService.joinLobby(user, invite.joinCode)
+        return repository.updateInviteStatus(inviteId, LobbyInviteStatus.ACCEPTED, nowProvider())?.toDto()
+            ?: error("lobby invite not found")
+    }
+
+    fun declineInvite(user: AuthUserDto, inviteId: String): LobbyInviteDto {
+        requirePendingInviteForUser(user, inviteId)
+        return repository.updateInviteStatus(inviteId, LobbyInviteStatus.DECLINED, nowProvider())?.toDto()
+            ?: error("lobby invite not found")
+    }
+
+    private fun requirePendingInviteForUser(user: AuthUserDto, inviteId: String): LobbyInviteRecord {
+        val invite = repository.findInviteById(inviteId) ?: error("lobby invite not found")
+        if (invite.toUserId != user.userId) {
+            throw UnauthorizedException()
+        }
+        if (invite.status != LobbyInviteStatus.PENDING) {
+            error("lobby invite is not pending")
+        }
+        return invite
+    }
+
+    private fun LobbyInviteRecord.toDto() =
+        LobbyInviteDto(
+            inviteId = inviteId,
+            lobbyId = lobbyId,
+            joinCode = joinCode,
+            from = SocialUserDto(fromUserId, fromUsername),
+            to = SocialUserDto(toUserId, toUsername),
+            status = status,
+            createdAt = createdAt,
+            respondedAt = respondedAt,
+        )
+}

--- a/src/main/kotlin/at/aau/se2/skyjo/service/LobbyInviteService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/LobbyInviteService.kt
@@ -4,6 +4,7 @@ import at.aau.se2.skyjo.model.auth.AuthUserDto
 import at.aau.se2.skyjo.model.lobby.LobbyStatus
 import at.aau.se2.skyjo.model.social.LobbyInviteDto
 import at.aau.se2.skyjo.model.social.LobbyInviteStatus
+import at.aau.se2.skyjo.model.social.RelationshipStatus
 import at.aau.se2.skyjo.model.social.SocialUserDto
 import at.aau.se2.skyjo.persistence.AuthRepository
 import at.aau.se2.skyjo.persistence.FriendRepository
@@ -59,6 +60,9 @@ class LobbyInviteService @Autowired constructor(
         if (lobby.players.none { it.userId == from.userId }) {
             error("only a lobby member can invite")
         }
+        if (lobby.players.any { it.userId == toUserId }) {
+            error("user is already in the lobby")
+        }
         if (repository.findPendingInvite(lobbyId, toUserId) != null) {
             error("lobby invite already exists")
         }
@@ -71,11 +75,11 @@ class LobbyInviteService @Autowired constructor(
             toUserId = toUserId,
             now = nowProvider(),
         )
-        return repository.findPendingInvite(lobbyId, toUserId)?.toDto() ?: error("lobby invite not found")
+        return repository.findPendingInvite(lobbyId, toUserId)?.toDto(from.userId) ?: error("lobby invite not found")
     }
 
     fun listInvites(user: AuthUserDto): List<LobbyInviteDto> =
-        repository.listPendingInvitesForUser(user.userId).map { it.toDto() }
+        repository.listPendingInvitesForUser(user.userId).map { it.toDto(user.userId) }
 
     fun acceptInvite(user: AuthUserDto, inviteId: String): LobbyInviteDto {
         val invite = requirePendingInviteForUser(user, inviteId)
@@ -85,13 +89,13 @@ class LobbyInviteService @Autowired constructor(
         }
 
         lobbyService.joinLobby(user, invite.joinCode)
-        return repository.updateInviteStatus(inviteId, LobbyInviteStatus.ACCEPTED, nowProvider())?.toDto()
+        return repository.updateInviteStatus(inviteId, LobbyInviteStatus.ACCEPTED, nowProvider())?.toDto(user.userId)
             ?: error("lobby invite not found")
     }
 
     fun declineInvite(user: AuthUserDto, inviteId: String): LobbyInviteDto {
         requirePendingInviteForUser(user, inviteId)
-        return repository.updateInviteStatus(inviteId, LobbyInviteStatus.DECLINED, nowProvider())?.toDto()
+        return repository.updateInviteStatus(inviteId, LobbyInviteStatus.DECLINED, nowProvider())?.toDto(user.userId)
             ?: error("lobby invite not found")
     }
 
@@ -106,13 +110,21 @@ class LobbyInviteService @Autowired constructor(
         return invite
     }
 
-    private fun LobbyInviteRecord.toDto() =
+    private fun relationshipStatus(viewerId: String, targetUserId: String): RelationshipStatus =
+        when {
+            friendRepository.areFriends(viewerId, targetUserId) -> RelationshipStatus.FRIENDS
+            friendRepository.findPendingRequest(viewerId, targetUserId) != null -> RelationshipStatus.OUTGOING_REQUEST
+            friendRepository.findPendingRequest(targetUserId, viewerId) != null -> RelationshipStatus.INCOMING_REQUEST
+            else -> RelationshipStatus.NONE
+        }
+
+    private fun LobbyInviteRecord.toDto(viewerId: String) =
         LobbyInviteDto(
             inviteId = inviteId,
             lobbyId = lobbyId,
             joinCode = joinCode,
-            from = SocialUserDto(fromUserId, fromUsername),
-            to = SocialUserDto(toUserId, toUsername),
+            from = SocialUserDto(fromUserId, fromUsername, relationshipStatus(viewerId, fromUserId)),
+            to = SocialUserDto(toUserId, toUsername, relationshipStatus(viewerId, toUserId)),
             status = status,
             createdAt = createdAt,
             respondedAt = respondedAt,

--- a/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
@@ -230,7 +230,7 @@ class LobbyService(
 
     private fun ensureUserCanEnterLobby(userId: String) {
         val current = getCurrentLobbyForUser(userId)
-        if (current != null && current.status == LobbyStatus.WAITING) {
+        if (current != null && current.status != LobbyStatus.CLOSED) {
             error("user is already in a lobby")
         }
     }

--- a/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
@@ -1,17 +1,50 @@
 package at.aau.se2.skyjo.service
 
+import at.aau.se2.skyjo.model.auth.AuthUserDto
 import at.aau.se2.skyjo.model.lobby.LobbyPlayer
 import at.aau.se2.skyjo.model.lobby.LobbyState
 import at.aau.se2.skyjo.model.lobby.LobbyStatus
-import org.springframework.stereotype.Service
+import at.aau.se2.skyjo.persistence.LobbyMemberRecord
+import at.aau.se2.skyjo.persistence.LobbyRecord
+import at.aau.se2.skyjo.persistence.LobbyRepository
+import java.security.SecureRandom
+import java.util.UUID
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
-@Service
-class LobbyService {
+interface JoinCodeGenerator {
+    fun generateCode(): String
+}
+
+class RandomJoinCodeGenerator : JoinCodeGenerator {
+    private val random = SecureRandom()
+    private val alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+
+    override fun generateCode(): String =
+        (1..6)
+            .map { alphabet[random.nextInt(alphabet.length)] }
+            .joinToString(separator = "")
+}
+
+interface LobbyIdGenerator {
+    fun generateId(): String
+}
+
+class RandomLobbyIdGenerator : LobbyIdGenerator {
+    override fun generateId(): String = UUID.randomUUID().toString()
+}
+
+class LobbyService(
+    private val repository: LobbyRepository? = null,
+    private val joinCodeGenerator: JoinCodeGenerator = RandomJoinCodeGenerator(),
+    private val idGenerator: LobbyIdGenerator = RandomLobbyIdGenerator(),
+    private val nowProvider: () -> Long = { System.currentTimeMillis() },
+) {
 
     private val lock = ReentrantLock()
     private var state = LobbyState()
+    private val inMemoryLobbies = mutableMapOf<String, LobbyState>()
+    private val inMemoryUserLobbyIds = mutableMapOf<String, String>()
 
     fun join(sessionId: String, nickname: String): LobbyState = lock.withLock {
         if (state.status == LobbyStatus.IN_GAME) {
@@ -64,5 +97,170 @@ class LobbyService {
 
     fun isPlayerInLobby(sessionId: String): Boolean = lock.withLock {
         state.players.any { it.sessionId == sessionId }
+    }
+
+    fun createLobby(user: AuthUserDto): LobbyState = lock.withLock {
+        ensureUserCanEnterLobby(user.userId)
+        val lobbyId = idGenerator.generateId()
+        val joinCode = generateUniqueJoinCode()
+        val now = nowProvider()
+        val host = LobbyPlayer(
+            sessionId = user.userId,
+            nickname = user.username,
+            isHost = true,
+            userId = user.userId,
+        )
+
+        repository?.let { repo ->
+            repo.createLobby(lobbyId, joinCode, user.userId, maxPlayers = DEFAULT_MAX_PLAYERS, now = now)
+            repo.upsertMember(lobbyId, user.userId, user.username, isHost = true, joinedAt = now)
+        } ?: run {
+            inMemoryLobbies[lobbyId] = LobbyState(
+                lobbyId = lobbyId,
+                joinCode = joinCode,
+                players = listOf(host),
+                maxPlayers = DEFAULT_MAX_PLAYERS,
+            )
+            inMemoryUserLobbyIds[user.userId] = lobbyId
+        }
+
+        getLobbyById(lobbyId) ?: error("created lobby is not available")
+    }
+
+    fun joinLobby(user: AuthUserDto, joinCode: String): LobbyState = lock.withLock {
+        val lobby = getLobbyByJoinCode(joinCode) ?: error("lobby not found")
+        if (lobby.status != LobbyStatus.WAITING) {
+            error("cannot join: lobby is not waiting")
+        }
+        val existingLobby = getCurrentLobbyForUser(user.userId)
+        if (existingLobby != null && existingLobby.lobbyId != lobby.lobbyId) {
+            error("user is already in a lobby")
+        }
+        if (lobby.players.any { it.userId == user.userId }) {
+            return lobby
+        }
+        if (lobby.players.size >= lobby.maxPlayers) {
+            error("cannot join: lobby is full (max ${lobby.maxPlayers} players)")
+        }
+
+        val lobbyId = lobby.lobbyId ?: error("lobby id is missing")
+        val now = nowProvider()
+        repository?.upsertMember(lobbyId, user.userId, user.username, isHost = false, joinedAt = now)
+            ?: run {
+                inMemoryLobbies[lobbyId] = lobby.copy(
+                    players = lobby.players + LobbyPlayer(
+                        sessionId = user.userId,
+                        nickname = user.username,
+                        isHost = false,
+                        userId = user.userId,
+                    ),
+                )
+                inMemoryUserLobbyIds[user.userId] = lobbyId
+            }
+
+        getLobbyById(lobbyId) ?: error("joined lobby is not available")
+    }
+
+    fun leaveLobby(userId: String, lobbyId: String): LobbyState = lock.withLock {
+        val lobby = getLobbyById(lobbyId) ?: error("lobby not found")
+        val remainingPlayers = lobby.players.filter { it.userId != userId }
+
+        repository?.removeMember(lobbyId, userId) ?: inMemoryUserLobbyIds.remove(userId)
+
+        if (remainingPlayers.isEmpty()) {
+            repository?.updateLobbyStatus(lobbyId, LobbyStatus.CLOSED, nowProvider())
+                ?: run { inMemoryLobbies[lobbyId] = lobby.copy(players = emptyList(), status = LobbyStatus.CLOSED) }
+            return getLobbyById(lobbyId) ?: lobby.copy(players = emptyList(), status = LobbyStatus.CLOSED)
+        }
+
+        if (remainingPlayers.none { it.isHost }) {
+            val newHost = remainingPlayers.first()
+            repository?.setHost(lobbyId, newHost.userId, isHost = true)
+                ?: run {
+                    inMemoryLobbies[lobbyId] = lobby.copy(
+                        players = remainingPlayers.mapIndexed { index, player ->
+                            if (index == 0) player.copy(isHost = true) else player.copy(isHost = false)
+                        },
+                    )
+                }
+        }
+
+        getLobbyById(lobbyId) ?: error("updated lobby is not available")
+    }
+
+    fun startGame(userId: String, lobbyId: String): LobbyState = lock.withLock {
+        val lobby = getLobbyById(lobbyId) ?: error("lobby not found")
+        val caller = lobby.players.find { it.userId == userId } ?: error("player not in lobby")
+        if (!caller.isHost) {
+            error("only the host can start the game")
+        }
+        if (lobby.players.size < 2) {
+            error("need at least 2 players to start")
+        }
+
+        repository?.updateLobbyStatus(lobbyId, LobbyStatus.IN_GAME, nowProvider())
+            ?: run { inMemoryLobbies[lobbyId] = lobby.copy(status = LobbyStatus.IN_GAME) }
+
+        getLobbyById(lobbyId) ?: error("started lobby is not available")
+    }
+
+    fun getLobbyById(lobbyId: String): LobbyState? = lock.withLock {
+        repository?.let { repo ->
+            repo.findLobbyById(lobbyId)?.let { record ->
+                record.toState(repo.listMembers(record.lobbyId))
+            }
+        } ?: inMemoryLobbies[lobbyId]
+    }
+
+    fun getCurrentLobbyForUser(userId: String): LobbyState? = lock.withLock {
+        repository?.let { repo ->
+            repo.findCurrentLobbyForUser(userId)?.let { record ->
+                record.toState(repo.listMembers(record.lobbyId))
+            }
+        } ?: inMemoryUserLobbyIds[userId]?.let(inMemoryLobbies::get)
+    }
+
+    private fun getLobbyByJoinCode(joinCode: String): LobbyState? {
+        return repository?.let { repo ->
+            repo.findLobbyByJoinCode(joinCode)?.let { record ->
+                record.toState(repo.listMembers(record.lobbyId))
+            }
+        } ?: inMemoryLobbies.values.firstOrNull { it.joinCode.equals(joinCode, ignoreCase = true) }
+    }
+
+    private fun ensureUserCanEnterLobby(userId: String) {
+        val current = getCurrentLobbyForUser(userId)
+        if (current != null && current.status == LobbyStatus.WAITING) {
+            error("user is already in a lobby")
+        }
+    }
+
+    private fun generateUniqueJoinCode(): String {
+        repeat(10) {
+            val code = joinCodeGenerator.generateCode()
+            if (getLobbyByJoinCode(code) == null) {
+                return code
+            }
+        }
+        error("could not generate unique lobby code")
+    }
+
+    private fun LobbyRecord.toState(members: List<LobbyMemberRecord>) = LobbyState(
+        lobbyId = lobbyId,
+        joinCode = joinCode,
+        players = members.map { member ->
+            LobbyPlayer(
+                sessionId = member.userId,
+                nickname = member.username,
+                isHost = member.isHost,
+                userId = member.userId,
+            )
+        },
+        status = status,
+        maxPlayers = maxPlayers,
+    )
+
+    private companion object {
+        const val DEFAULT_MAX_PLAYERS = 6
     }
 }

--- a/src/main/kotlin/at/aau/se2/skyjo/service/StatsService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/StatsService.kt
@@ -1,0 +1,78 @@
+package at.aau.se2.skyjo.service
+
+import at.aau.se2.skyjo.model.stats.LeaderboardEntryDto
+import at.aau.se2.skyjo.model.stats.PlayerStatsDto
+import at.aau.se2.skyjo.persistence.AuthRepository
+import at.aau.se2.skyjo.persistence.PlayerStatsRecord
+import at.aau.se2.skyjo.persistence.StatsRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Service
+
+@Service
+class StatsService @Autowired constructor(
+    private val repository: StatsRepository,
+    private val authRepository: AuthRepository,
+) {
+
+    private var nowProvider: () -> Long = { System.currentTimeMillis() }
+
+    internal constructor(
+        repository: StatsRepository,
+        authRepository: AuthRepository,
+        nowProvider: () -> Long,
+    ) : this(repository, authRepository) {
+        this.nowProvider = nowProvider
+    }
+
+    fun recordGameResult(gameId: String, totalScores: Map<String, Int>) {
+        if (totalScores.isEmpty()) {
+            return
+        }
+        val winningScore = totalScores.values.min()
+        val winners = totalScores.filterValues { it == winningScore }.keys
+        val now = nowProvider()
+
+        totalScores.forEach { (userId, score) ->
+            repository.recordResult(userId, totalScore = score, won = userId in winners, now = now)
+        }
+    }
+
+    fun getStats(userId: String): PlayerStatsDto {
+        repository.findStats(userId)?.let { return it.toDto() }
+        val user = authRepository.findUserById(userId) ?: throw UnauthorizedException()
+        return PlayerStatsDto(
+            userId = user.userId,
+            username = user.username,
+            gamesPlayed = 0,
+            wins = 0,
+            totalScore = 0,
+            bestScore = null,
+            averageScore = 0.0,
+        )
+    }
+
+    fun leaderboard(limit: Int): List<LeaderboardEntryDto> =
+        repository.leaderboard(limit.coerceIn(1, 100)).mapIndexed { index, record ->
+            LeaderboardEntryDto(
+                rank = index + 1,
+                userId = record.userId,
+                username = record.username,
+                averageScore = record.averageScore,
+                wins = record.wins,
+                gamesPlayed = record.gamesPlayed,
+                bestScore = record.bestScore,
+                totalScore = record.totalScore,
+            )
+        }
+
+    private fun PlayerStatsRecord.toDto() =
+        PlayerStatsDto(
+            userId = userId,
+            username = username,
+            gamesPlayed = gamesPlayed,
+            wins = wins,
+            totalScore = totalScore,
+            bestScore = bestScore,
+            averageScore = averageScore,
+        )
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/config/WebSocketConfigTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/config/WebSocketConfigTest.kt
@@ -3,63 +3,109 @@ package at.aau.se2.skyjo.config
 import at.aau.se2.skyjo.model.auth.AuthPrincipal
 import at.aau.se2.skyjo.model.auth.AuthUserDto
 import at.aau.se2.skyjo.service.AuthService
-import at.aau.se2.skyjo.service.UnauthorizedException
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
 import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.web.socket.WebSocketHandler
 import java.net.URI
 
 class WebSocketConfigTest {
 
     private val authService: AuthService = mock()
-    private val handler = AuthPrincipalHandshakeHandler(authService)
+    private val interceptor = TicketHandshakeInterceptor(authService)
+    private val handler = AuthPrincipalHandshakeHandler()
 
     @Test
-    fun `valid websocket ticket creates authenticated principal`() {
+    fun `valid ticket sets principal in attributes and returns true`() {
         whenever(authService.consumeWebSocketTicket("ticket-123"))
             .thenReturn(AuthUserDto(userId = "user-1", username = "Alice"))
 
-        val principal = handler.determinePrincipal(
+        val attrs = mutableMapOf<String, Any>()
+        val result = interceptor.beforeHandshake(
             requestWithUri("http://localhost/ws?ticket=ticket-123"),
-        ) as AuthPrincipal
+            mockResponse(),
+            mock(),
+            attrs,
+        )
 
+        assertTrue(result)
+        val principal = attrs[TicketHandshakeInterceptor.ATTR_PRINCIPAL] as AuthPrincipal
         assertEquals("user-1", principal.name)
         assertEquals("Alice", principal.username)
     }
 
     @Test
-    fun `missing websocket ticket is rejected`() {
-        assertThrows<UnauthorizedException> {
-            handler.determinePrincipal(
-                requestWithUri("http://localhost/ws"),
-            )
-        }
+    fun `missing ticket returns 401 and false`() {
+        val response = mockResponse()
+
+        val result = interceptor.beforeHandshake(
+            requestWithUri("http://localhost/ws"),
+            response,
+            mock(),
+            mutableMapOf(),
+        )
+
+        assertFalse(result)
+        verify(response).setStatusCode(HttpStatus.UNAUTHORIZED)
     }
 
     @Test
-    fun `invalid websocket ticket is rejected`() {
+    fun `invalid ticket returns 401 and false`() {
         whenever(authService.consumeWebSocketTicket("bad-ticket")).thenReturn(null)
+        val response = mockResponse()
 
-        assertThrows<UnauthorizedException> {
-            handler.determinePrincipal(
-                requestWithUri("http://localhost/ws?ticket=bad-ticket"),
-            )
-        }
+        val result = interceptor.beforeHandshake(
+            requestWithUri("http://localhost/ws?ticket=bad-ticket"),
+            response,
+            mock(),
+            mutableMapOf(),
+        )
+
+        assertFalse(result)
+        verify(response).setStatusCode(HttpStatus.UNAUTHORIZED)
     }
 
     @Test
-    fun `url encoded websocket ticket is decoded before validation`() {
+    fun `url encoded ticket is decoded before validation`() {
         whenever(authService.consumeWebSocketTicket("ticket/value"))
             .thenReturn(AuthUserDto(userId = "user-1", username = "Alice"))
 
-        val principal = handler.determinePrincipal(
+        val attrs = mutableMapOf<String, Any>()
+        val result = interceptor.beforeHandshake(
             requestWithUri("http://localhost/ws?ticket=ticket%2Fvalue"),
+            mockResponse(),
+            mock(),
+            attrs,
         )
 
-        assertEquals("user-1", principal.name)
+        assertTrue(result)
+        assertNotNull(attrs[TicketHandshakeInterceptor.ATTR_PRINCIPAL])
+    }
+
+    @Test
+    fun `determineUser reads principal from attributes`() {
+        val principal = AuthPrincipal("user-1", "Alice")
+        val attrs = mapOf<String, Any>(TicketHandshakeInterceptor.ATTR_PRINCIPAL to principal)
+
+        val result = handler.determineUser(requestWithUri("http://localhost/ws"), mock<WebSocketHandler>(), attrs)
+
+        assertEquals(principal, result)
+    }
+
+    @Test
+    fun `determineUser returns null when principal is absent from attributes`() {
+        val result = handler.determineUser(requestWithUri("http://localhost/ws"), mock<WebSocketHandler>(), emptyMap<String, Any>())
+
+        assertNull(result)
     }
 
     private fun requestWithUri(uri: String): ServerHttpRequest {
@@ -67,4 +113,6 @@ class WebSocketConfigTest {
         whenever(request.uri).thenReturn(URI(uri))
         return request
     }
+
+    private fun mockResponse(): ServerHttpResponse = mock()
 }

--- a/src/test/kotlin/at/aau/se2/skyjo/config/WebSocketConfigTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/config/WebSocketConfigTest.kt
@@ -1,0 +1,70 @@
+package at.aau.se2.skyjo.config
+
+import at.aau.se2.skyjo.model.auth.AuthPrincipal
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.service.AuthService
+import at.aau.se2.skyjo.service.UnauthorizedException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.http.server.ServerHttpRequest
+import java.net.URI
+
+class WebSocketConfigTest {
+
+    private val authService: AuthService = mock()
+    private val handler = AuthPrincipalHandshakeHandler(authService)
+
+    @Test
+    fun `valid websocket ticket creates authenticated principal`() {
+        whenever(authService.consumeWebSocketTicket("ticket-123"))
+            .thenReturn(AuthUserDto(userId = "user-1", username = "Alice"))
+
+        val principal = handler.determinePrincipal(
+            requestWithUri("http://localhost/ws?ticket=ticket-123"),
+        ) as AuthPrincipal
+
+        assertEquals("user-1", principal.name)
+        assertEquals("Alice", principal.username)
+    }
+
+    @Test
+    fun `missing websocket ticket is rejected`() {
+        assertThrows<UnauthorizedException> {
+            handler.determinePrincipal(
+                requestWithUri("http://localhost/ws"),
+            )
+        }
+    }
+
+    @Test
+    fun `invalid websocket ticket is rejected`() {
+        whenever(authService.consumeWebSocketTicket("bad-ticket")).thenReturn(null)
+
+        assertThrows<UnauthorizedException> {
+            handler.determinePrincipal(
+                requestWithUri("http://localhost/ws?ticket=bad-ticket"),
+            )
+        }
+    }
+
+    @Test
+    fun `url encoded websocket ticket is decoded before validation`() {
+        whenever(authService.consumeWebSocketTicket("ticket/value"))
+            .thenReturn(AuthUserDto(userId = "user-1", username = "Alice"))
+
+        val principal = handler.determinePrincipal(
+            requestWithUri("http://localhost/ws?ticket=ticket%2Fvalue"),
+        )
+
+        assertEquals("user-1", principal.name)
+    }
+
+    private fun requestWithUri(uri: String): ServerHttpRequest {
+        val request = mock<ServerHttpRequest>()
+        whenever(request.uri).thenReturn(URI(uri))
+        return request
+    }
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/AuthControllerTest.kt
@@ -1,0 +1,119 @@
+package at.aau.se2.skyjo.controller
+
+import at.aau.se2.skyjo.model.auth.AuthResponse
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.auth.ErrorResponse
+import at.aau.se2.skyjo.model.auth.LoginRequest
+import at.aau.se2.skyjo.model.auth.RegisterRequest
+import at.aau.se2.skyjo.model.auth.WsTicketResponse
+import at.aau.se2.skyjo.service.AuthService
+import at.aau.se2.skyjo.service.DuplicateUsernameException
+import at.aau.se2.skyjo.service.InvalidCredentialsException
+import at.aau.se2.skyjo.service.UnauthorizedException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+
+class AuthControllerTest {
+
+    private val authService: AuthService = mock()
+    private val authSupport = AuthSupport(authService)
+    private val controller = AuthController(authService, authSupport)
+
+    @Test
+    fun `register returns created auth response`() {
+        val response = authResponse()
+        whenever(authService.register("Alice", "password123")).thenReturn(response)
+
+        val result = controller.register(RegisterRequest("Alice", "password123"))
+
+        assertEquals(HttpStatus.CREATED, result.statusCode)
+        assertEquals(response, result.body)
+    }
+
+    @Test
+    fun `duplicate register returns conflict`() {
+        whenever(authService.register(any(), any())).thenThrow(DuplicateUsernameException())
+
+        val result = controller.register(RegisterRequest("Alice", "password123"))
+
+        assertEquals(HttpStatus.CONFLICT, result.statusCode)
+        assertEquals("Username is already taken", (result.body as ErrorResponse).message)
+    }
+
+    @Test
+    fun `login returns auth response`() {
+        val response = authResponse()
+        whenever(authService.login("Alice", "password123")).thenReturn(response)
+
+        val result = controller.login(LoginRequest("Alice", "password123"))
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals(response, result.body)
+    }
+
+    @Test
+    fun `login returns generic unauthorized on invalid credentials`() {
+        whenever(authService.login(any(), any())).thenThrow(InvalidCredentialsException())
+
+        val result = controller.login(LoginRequest("Alice", "bad-password"))
+
+        assertEquals(HttpStatus.UNAUTHORIZED, result.statusCode)
+        assertEquals("Invalid username or password", (result.body as ErrorResponse).message)
+    }
+
+    @Test
+    fun `me resolves bearer token`() {
+        whenever(authService.requireUser("token")).thenReturn(AuthUserDto("user-1", "Alice"))
+
+        val result = controller.me("Bearer token")
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals("Alice", (result.body as AuthUserDto).username)
+    }
+
+    @Test
+    fun `me returns unauthorized when bearer token is missing`() {
+        val result = controller.me(null)
+
+        assertEquals(HttpStatus.UNAUTHORIZED, result.statusCode)
+        assertEquals("Authentication required", (result.body as ErrorResponse).message)
+    }
+
+    @Test
+    fun `logout revokes bearer token`() {
+        val result = controller.logout("Bearer token")
+
+        assertEquals(HttpStatus.NO_CONTENT, result.statusCode)
+        verify(authService).logout("token")
+    }
+
+    @Test
+    fun `ws ticket requires valid bearer token`() {
+        whenever(authService.createWebSocketTicket("token")).thenReturn(WsTicketResponse("ticket", 2_000L))
+
+        val result = controller.createWebSocketTicket("Bearer token")
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals("ticket", (result.body as WsTicketResponse).ticket)
+    }
+
+    @Test
+    fun `ws ticket returns unauthorized for invalid token`() {
+        whenever(authService.createWebSocketTicket("token")).thenThrow(UnauthorizedException())
+
+        val result = controller.createWebSocketTicket("Bearer token")
+
+        assertEquals(HttpStatus.UNAUTHORIZED, result.statusCode)
+        assertEquals("Authentication required", (result.body as ErrorResponse).message)
+    }
+
+    private fun authResponse() = AuthResponse(
+        token = "token",
+        user = AuthUserDto(userId = "user-1", username = "Alice"),
+    )
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/FriendControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/FriendControllerTest.kt
@@ -1,0 +1,83 @@
+package at.aau.se2.skyjo.controller
+
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.auth.ErrorResponse
+import at.aau.se2.skyjo.model.social.FriendDto
+import at.aau.se2.skyjo.model.social.FriendRequestDto
+import at.aau.se2.skyjo.model.social.FriendRequestStatus
+import at.aau.se2.skyjo.model.social.SendFriendRequestRequest
+import at.aau.se2.skyjo.model.social.SocialUserDto
+import at.aau.se2.skyjo.service.AuthService
+import at.aau.se2.skyjo.service.FriendService
+import at.aau.se2.skyjo.service.UnauthorizedException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+
+class FriendControllerTest {
+
+    private val authService: AuthService = mock()
+    private val friendService: FriendService = mock()
+    private val authSupport = AuthSupport(authService)
+    private val controller = FriendController(friendService, authSupport)
+
+    @Test
+    fun `searchUsers requires auth and returns users`() {
+        whenever(authService.requireUser("token")).thenReturn(user())
+        whenever(friendService.searchUsers(user(), "bo")).thenReturn(
+            listOf(SocialUserDto("user-b", "Bob")),
+        )
+
+        val result = controller.searchUsers("bo", "Bearer token")
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals("Bob", (result.body as List<*>).filterIsInstance<SocialUserDto>().single().username)
+    }
+
+    @Test
+    fun `sendFriendRequest creates request`() {
+        whenever(authService.requireUser("token")).thenReturn(user())
+        whenever(friendService.sendFriendRequest(user(), "user-b")).thenReturn(request())
+
+        val result = controller.sendFriendRequest(SendFriendRequestRequest("user-b"), "Bearer token")
+
+        assertEquals(HttpStatus.CREATED, result.statusCode)
+        assertEquals("request-1", (result.body as FriendRequestDto).requestId)
+    }
+
+    @Test
+    fun `listFriends returns authenticated friends`() {
+        whenever(authService.requireUser("token")).thenReturn(user())
+        whenever(friendService.listFriends(user())).thenReturn(
+            listOf(FriendDto("user-b", "Bob", online = true, currentLobbyId = "lobby-1")),
+        )
+
+        val result = controller.listFriends("Bearer token")
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals("Bob", (result.body as List<*>).filterIsInstance<FriendDto>().single().username)
+    }
+
+    @Test
+    fun `friend endpoints return unauthorized for invalid token`() {
+        whenever(authService.requireUser("bad")).thenThrow(UnauthorizedException())
+
+        val result = controller.listFriends("Bearer bad")
+
+        assertEquals(HttpStatus.UNAUTHORIZED, result.statusCode)
+        assertEquals("Authentication required", (result.body as ErrorResponse).message)
+    }
+
+    private fun user() = AuthUserDto(userId = "user-a", username = "Alice")
+
+    private fun request() = FriendRequestDto(
+        requestId = "request-1",
+        from = SocialUserDto("user-a", "Alice"),
+        to = SocialUserDto("user-b", "Bob"),
+        status = FriendRequestStatus.PENDING,
+        createdAt = 1_000L,
+        respondedAt = null,
+    )
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/FriendControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/FriendControllerTest.kt
@@ -4,6 +4,7 @@ import at.aau.se2.skyjo.model.auth.AuthUserDto
 import at.aau.se2.skyjo.model.auth.ErrorResponse
 import at.aau.se2.skyjo.model.social.FriendDto
 import at.aau.se2.skyjo.model.social.FriendRequestDto
+import at.aau.se2.skyjo.model.social.FriendRequestsResponse
 import at.aau.se2.skyjo.model.social.FriendRequestStatus
 import at.aau.se2.skyjo.model.social.SendFriendRequestRequest
 import at.aau.se2.skyjo.model.social.SocialUserDto
@@ -61,6 +62,49 @@ class FriendControllerTest {
     }
 
     @Test
+    fun `listFriendRequests returns incoming and outgoing requests`() {
+        whenever(authService.requireUser("token")).thenReturn(user())
+        whenever(friendService.listFriendRequests(user())).thenReturn(
+            FriendRequestsResponse(
+                incoming = listOf(request(requestId = "incoming-1")),
+                outgoing = listOf(request(requestId = "outgoing-1")),
+            ),
+        )
+
+        val result = controller.listFriendRequests("Bearer token")
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals("incoming-1", (result.body as FriendRequestsResponse).incoming.single().requestId)
+        assertEquals("outgoing-1", (result.body as FriendRequestsResponse).outgoing.single().requestId)
+    }
+
+    @Test
+    fun `acceptFriendRequest returns accepted request`() {
+        whenever(authService.requireUser("token")).thenReturn(user("user-b", "Bob"))
+        whenever(friendService.acceptFriendRequest(user("user-b", "Bob"), "request-1")).thenReturn(
+            request(status = FriendRequestStatus.ACCEPTED),
+        )
+
+        val result = controller.acceptFriendRequest("request-1", "Bearer token")
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals(FriendRequestStatus.ACCEPTED, (result.body as FriendRequestDto).status)
+    }
+
+    @Test
+    fun `declineFriendRequest returns declined request`() {
+        whenever(authService.requireUser("token")).thenReturn(user("user-b", "Bob"))
+        whenever(friendService.declineFriendRequest(user("user-b", "Bob"), "request-1")).thenReturn(
+            request(status = FriendRequestStatus.DECLINED),
+        )
+
+        val result = controller.declineFriendRequest("request-1", "Bearer token")
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals(FriendRequestStatus.DECLINED, (result.body as FriendRequestDto).status)
+    }
+
+    @Test
     fun `friend endpoints return unauthorized for invalid token`() {
         whenever(authService.requireUser("bad")).thenThrow(UnauthorizedException())
 
@@ -70,14 +114,44 @@ class FriendControllerTest {
         assertEquals("Authentication required", (result.body as ErrorResponse).message)
     }
 
-    private fun user() = AuthUserDto(userId = "user-a", username = "Alice")
+    @Test
+    fun `friend endpoints map not found errors to not found`() {
+        whenever(authService.requireUser("token")).thenReturn(user("user-b", "Bob"))
+        whenever(friendService.acceptFriendRequest(user("user-b", "Bob"), "missing")).thenThrow(
+            IllegalStateException("friend request not found"),
+        )
 
-    private fun request() = FriendRequestDto(
-        requestId = "request-1",
+        val result = controller.acceptFriendRequest("missing", "Bearer token")
+
+        assertEquals(HttpStatus.NOT_FOUND, result.statusCode)
+        assertEquals("friend request not found", (result.body as ErrorResponse).message)
+    }
+
+    @Test
+    fun `friend endpoints map invalid operations to bad request`() {
+        whenever(authService.requireUser("token")).thenReturn(user())
+        whenever(friendService.sendFriendRequest(user(), "user-b")).thenThrow(
+            IllegalStateException("users are already friends"),
+        )
+
+        val result = controller.sendFriendRequest(SendFriendRequestRequest("user-b"), "Bearer token")
+
+        assertEquals(HttpStatus.BAD_REQUEST, result.statusCode)
+        assertEquals("users are already friends", (result.body as ErrorResponse).message)
+    }
+
+    private fun user(userId: String = "user-a", username: String = "Alice") =
+        AuthUserDto(userId = userId, username = username)
+
+    private fun request(
+        requestId: String = "request-1",
+        status: FriendRequestStatus = FriendRequestStatus.PENDING,
+    ) = FriendRequestDto(
+        requestId = requestId,
         from = SocialUserDto("user-a", "Alice"),
         to = SocialUserDto("user-b", "Bob"),
-        status = FriendRequestStatus.PENDING,
+        status = status,
         createdAt = 1_000L,
-        respondedAt = null,
+        respondedAt = if (status == FriendRequestStatus.PENDING) null else 2_000L,
     )
 }

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/GameControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/GameControllerTest.kt
@@ -44,17 +44,19 @@ class GameControllerTest {
         roundNumber = 1,
         totalScores = emptyList(),
         gameOver = false,
+        gameId = "game-1",
+        lobbyId = "lobby-1",
     )
 
     @Test
-    fun `gameAction broadcasts updated state to topic game`() {
+    fun `gameAction broadcasts updated state to game-specific topic`() {
         val update = stubGameUpdate()
         whenever(gameService.processAction(any(), any())).thenReturn(update)
         val action = GameActionMessage(ActionType.DRAW, source = DrawSource.DECK)
 
         controller.gameAction(action, headerWithUser("p1"))
 
-        verify(messagingTemplate).convertAndSend("/topic/game", update)
+        verify(messagingTemplate).convertAndSend("/topic/games/game-1", update)
     }
 
     @Test
@@ -100,7 +102,7 @@ class GameControllerTest {
 
         controller.playActionCard(command, headerWithUser("p1"))
 
-        verify(messagingTemplate).convertAndSend("/topic/game", update)
+        verify(messagingTemplate).convertAndSend("/topic/games/game-1", update)
         verify(messagingTemplate).convertAndSendToUser("p1", "/queue/action-card-results", privateResult)
         verify(messagingTemplate, never()).convertAndSendToUser(eq("p2"), eq("/queue/action-card-results"), any())
     }

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyControllerTest.kt
@@ -1,4 +1,5 @@
 package at.aau.se2.skyjo.controller
+import at.aau.se2.skyjo.model.auth.AuthUserDto
 import io.mockk.*
 import io.mockk.impl.annotations.MockK
 import io.mockk.impl.annotations.RelaxedMockK
@@ -33,6 +34,9 @@ class LobbyControllerTest {
 
     @MockK
     lateinit var principal: Principal
+
+    @MockK
+    lateinit var authSupport: AuthSupport
 
     private val playerId = "player-123"
 
@@ -160,6 +164,92 @@ class LobbyControllerTest {
                     any<LobbyUpdateMessage>()
                 )
             }
+        }
+
+        @Test
+        fun `joinLobby reconnectet authentifizierten Spieler ueber UserId in sein gespeichertes Spiel`() {
+            val gameRepository = mockk<at.aau.se2.skyjo.persistence.GameRepository>()
+            val gameState = GameUpdateMessage(
+                phase = at.aau.se2.skyjo.game.model.GamePhase.AWAITING_DRAW,
+                currentPlayerId = playerId,
+                players = emptyList(),
+                discardTopCard = null,
+                drawnCard = null,
+                roundResult = null,
+                roundNumber = 1,
+                totalScores = emptyList(),
+                gameOver = false,
+                gameId = "game-1",
+                lobbyId = "lobby-1",
+            )
+            controller = LobbyController(lobbyService, gameService, messagingTemplate, gameRepository)
+            every { gameRepository.getPlayerGame(playerId) } returns "game-1"
+            every { gameService.reconnectPlayer(playerId, "Alice", "game-1") } returns gameState
+
+            controller.joinLobby(PlayerMessage("Alice"), headerAccessor)
+
+            verify { gameRepository.getPlayerGame(playerId) }
+            verify { gameService.reconnectPlayer(playerId, "Alice", "game-1") }
+            verify(exactly = 0) { gameService.getActiveGameId() }
+            verify { messagingTemplate.convertAndSendToUser(playerId, "/queue/gamestate", gameState) }
+            verify { lobbyService wasNot Called }
+        }
+    }
+
+    @Nested
+    inner class RestPresenceTests {
+        private val user = AuthUserDto(userId = "user-1", username = "Alice")
+        private val authHeader = "Bearer token"
+
+        @Test
+        fun `createLobby aktualisiert Friend Presence mit neuer Lobby`() {
+            val lobby = LobbyState(
+                lobbyId = "lobby-1",
+                joinCode = "ABC123",
+                players = listOf(LobbyPlayer(sessionId = "user-1", nickname = "Alice", isHost = true, userId = "user-1")),
+            )
+            controller = LobbyController(lobbyService, gameService, messagingTemplate, null, authSupport)
+            every { authSupport.requireUser(authHeader) } returns user
+            every { authSupport.markUserConnected("user-1", "lobby-1") } just Runs
+            every { lobbyService.createLobby(user) } returns lobby
+
+            controller.createLobby(authHeader)
+
+            verify { authSupport.markUserConnected("user-1", "lobby-1") }
+        }
+
+        @Test
+        fun `joinLobbyByCode aktualisiert Friend Presence mit beigetretener Lobby`() {
+            val lobby = LobbyState(
+                lobbyId = "lobby-1",
+                joinCode = "ABC123",
+                players = listOf(LobbyPlayer(sessionId = "user-1", nickname = "Alice", isHost = false, userId = "user-1")),
+            )
+            controller = LobbyController(lobbyService, gameService, messagingTemplate, null, authSupport)
+            every { authSupport.requireUser(authHeader) } returns user
+            every { authSupport.markUserConnected("user-1", "lobby-1") } just Runs
+            every { lobbyService.joinLobby(user, "ABC123") } returns lobby
+
+            controller.joinLobbyByCode("ABC123", authHeader)
+
+            verify { authSupport.markUserConnected("user-1", "lobby-1") }
+        }
+
+        @Test
+        fun `leaveLobbyById entfernt Lobby aus Friend Presence`() {
+            val lobby = LobbyState(
+                lobbyId = "lobby-1",
+                joinCode = "ABC123",
+                players = emptyList(),
+            )
+            controller = LobbyController(lobbyService, gameService, messagingTemplate, null, authSupport)
+            every { authSupport.requireUser(authHeader) } returns user
+            every { authSupport.markUserConnected("user-1", null) } just Runs
+            every { lobbyService.leaveLobby("user-1", "lobby-1") } returns lobby
+
+            controller.leaveLobbyById("lobby-1", authHeader)
+
+            verify { authSupport.markUserConnected("user-1", null) }
         }
     }
 

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyControllerTest.kt
@@ -358,6 +358,7 @@ class LobbyControllerTest {
 
             verify { messagingTemplate.convertAndSend("/topic/lobbies/ABC123", any<LobbyUpdateMessage>()) }
             verify { messagingTemplate.convertAndSend("/topic/games/game-1", gameUpdateMessage) }
+            verify { messagingTemplate.convertAndSendToUser(playerId, "/queue/gamestate", gameUpdateMessage) }
         }
     }
 }

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyControllerTest.kt
@@ -139,6 +139,8 @@ class LobbyControllerTest {
             every { lobbyService.getState() } returns currentState
 
             val updatedState = mockk<LobbyState> {
+                every { lobbyId } returns null
+                every { joinCode } returns null
                 every { players } returns listOf(mockk {
                     every { nickname } returns trimmedName
                     every { isHost } returns false
@@ -176,6 +178,8 @@ class LobbyControllerTest {
         @Test
         fun `leaveLobby verlaesst erfolgreich und schickt Update an Topic`() {
             val updatedState = mockk<LobbyState> {
+                every { lobbyId } returns null
+                every { joinCode } returns null
                 every { players } returns emptyList()
                 every { status } returns mockk()
                 every { maxPlayers } returns 4
@@ -227,6 +231,8 @@ class LobbyControllerTest {
         @Test
         fun `startGame sendet Fehler, wenn gameService throws`() {
             val lobbyState = mockk<LobbyState> {
+                every { lobbyId } returns null
+                every { joinCode } returns null
                 every { players } returns emptyList()
                 every { status } returns mockk()
                 every { maxPlayers } returns 4
@@ -254,6 +260,8 @@ class LobbyControllerTest {
                 every { isHost } returns true
             })
             val lobbyState = mockk<LobbyState> {
+                every { lobbyId } returns null
+                every { joinCode } returns null
                 every { players } returns playersList
                 every { status } returns mockk()
                 every { maxPlayers } returns 4
@@ -282,6 +290,8 @@ class LobbyControllerTest {
         fun `startGame startet Spiel mit Custom Config wenn Message vorhanden ist`() {
             val playersList = emptyList<LobbyPlayer>()
             val lobbyState = mockk<LobbyState> {
+                every { lobbyId } returns null
+                every { joinCode } returns null
                 every { players } returns playersList
                 every { status } returns mockk()
                 every { maxPlayers } returns 4

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyControllerTest.kt
@@ -240,7 +240,9 @@ class LobbyControllerTest {
             every { lobbyService.startGame(playerId) } returns lobbyState
 
             val errorMessage = "Game initialization failed"
-            every { gameService.startGame(any(), any()) } throws RuntimeException(errorMessage)
+            every {
+                gameService.startGame(any<List<LobbyPlayer>>(), any<GameConfig>())
+            } throws RuntimeException(errorMessage)
 
             controller.startGame(StartGameMessage(3, 100), headerAccessor)
 
@@ -269,7 +271,9 @@ class LobbyControllerTest {
             every { lobbyService.startGame(playerId) } returns lobbyState
 
             // Verwendet nun dein GameUpdateMessage DTO
-            val gameUpdateMessage = mockk<GameUpdateMessage>()
+            val gameUpdateMessage = mockk<GameUpdateMessage> {
+                every { gameId } returns null
+            }
 
             val configSlot = slot<GameConfig>()
             every { gameService.startGame(eq(playersList), capture(configSlot)) } returns gameUpdateMessage
@@ -298,7 +302,9 @@ class LobbyControllerTest {
             }
             every { lobbyService.startGame(playerId) } returns lobbyState
 
-            val gameUpdateMessage = mockk<GameUpdateMessage>()
+            val gameUpdateMessage = mockk<GameUpdateMessage> {
+                every { gameId } returns null
+            }
             val customMessage = StartGameMessage(maxRounds = 7, targetScore = 50)
 
             every {
@@ -312,6 +318,46 @@ class LobbyControllerTest {
 
             verify { messagingTemplate.convertAndSend("/topic/lobby", any<LobbyUpdateMessage>()) }
             verify { messagingTemplate.convertAndSend("/topic/game", gameUpdateMessage) }
+        }
+
+        @Test
+        fun `startGame startet aktuelles Join-Code Lobby-Spiel auf Game Topic`() {
+            val playersList = listOf<LobbyPlayer>(
+                mockk {
+                    every { sessionId } returns playerId
+                    every { userId } returns playerId
+                    every { nickname } returns "Alice"
+                    every { isHost } returns true
+                },
+            )
+            val lobbyState = mockk<LobbyState> {
+                every { lobbyId } returns "lobby-1"
+                every { joinCode } returns "ABC123"
+                every { players } returns playersList
+                every { status } returns LobbyStatus.IN_GAME
+                every { maxPlayers } returns 4
+            }
+            val gameUpdateMessage = GameUpdateMessage(
+                phase = at.aau.se2.skyjo.game.model.GamePhase.AWAITING_DRAW,
+                currentPlayerId = playerId,
+                players = emptyList(),
+                discardTopCard = null,
+                drawnCard = null,
+                roundResult = null,
+                roundNumber = 1,
+                totalScores = emptyList(),
+                gameOver = false,
+                gameId = "game-1",
+                lobbyId = "lobby-1",
+            )
+            every { lobbyService.getCurrentLobbyForUser(playerId) } returns lobbyState
+            every { lobbyService.startGame(userId = playerId, lobbyId = "lobby-1") } returns lobbyState
+            every { gameService.startGame("lobby-1", playersList, any()) } returns gameUpdateMessage
+
+            controller.startGame(StartGameMessage(3, 100), headerAccessor)
+
+            verify { messagingTemplate.convertAndSend("/topic/lobbies/ABC123", any<LobbyUpdateMessage>()) }
+            verify { messagingTemplate.convertAndSend("/topic/games/game-1", gameUpdateMessage) }
         }
     }
 }

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyInviteControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyInviteControllerTest.kt
@@ -1,15 +1,18 @@
 package at.aau.se2.skyjo.controller
 
 import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.auth.ErrorResponse
 import at.aau.se2.skyjo.model.social.LobbyInviteDto
 import at.aau.se2.skyjo.model.social.LobbyInviteRequest
 import at.aau.se2.skyjo.model.social.LobbyInviteStatus
 import at.aau.se2.skyjo.model.social.SocialUserDto
 import at.aau.se2.skyjo.service.AuthService
 import at.aau.se2.skyjo.service.LobbyInviteService
+import at.aau.se2.skyjo.service.UnauthorizedException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
@@ -35,6 +38,28 @@ class LobbyInviteControllerTest {
     }
 
     @Test
+    fun `createInvite returns unauthorized without sending websocket message`() {
+        whenever(authService.requireUser("bad")).thenThrow(UnauthorizedException())
+
+        val result = controller.createInvite("lobby-1", LobbyInviteRequest("user-b"), "Bearer bad")
+
+        assertEquals(HttpStatus.UNAUTHORIZED, result.statusCode)
+        assertEquals("Authentication required", (result.body as ErrorResponse).message)
+        verify(messagingTemplate, never()).convertAndSendToUser("user-b", "/queue/invites", invite())
+    }
+
+    @Test
+    fun `listInvites returns pending invites`() {
+        whenever(authService.requireUser("token")).thenReturn(user("user-b", "Bob"))
+        whenever(inviteService.listInvites(user("user-b", "Bob"))).thenReturn(listOf(invite()))
+
+        val result = controller.listInvites("Bearer token")
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals("invite-1", (result.body as List<*>).filterIsInstance<LobbyInviteDto>().single().inviteId)
+    }
+
+    @Test
     fun `acceptInvite returns accepted invite`() {
         whenever(authService.requireUser("token")).thenReturn(user("user-b", "Bob"))
         whenever(inviteService.acceptInvite(user("user-b", "Bob"), "invite-1")).thenReturn(
@@ -45,6 +70,45 @@ class LobbyInviteControllerTest {
 
         assertEquals(HttpStatus.OK, result.statusCode)
         assertEquals(LobbyInviteStatus.ACCEPTED, (result.body as LobbyInviteDto).status)
+    }
+
+    @Test
+    fun `declineInvite returns declined invite`() {
+        whenever(authService.requireUser("token")).thenReturn(user("user-b", "Bob"))
+        whenever(inviteService.declineInvite(user("user-b", "Bob"), "invite-1")).thenReturn(
+            invite(status = LobbyInviteStatus.DECLINED),
+        )
+
+        val result = controller.declineInvite("invite-1", "Bearer token")
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals(LobbyInviteStatus.DECLINED, (result.body as LobbyInviteDto).status)
+    }
+
+    @Test
+    fun `invite endpoints map not found errors to not found`() {
+        whenever(authService.requireUser("token")).thenReturn(user("user-b", "Bob"))
+        whenever(inviteService.acceptInvite(user("user-b", "Bob"), "missing")).thenThrow(
+            IllegalStateException("lobby invite not found"),
+        )
+
+        val result = controller.acceptInvite("missing", "Bearer token")
+
+        assertEquals(HttpStatus.NOT_FOUND, result.statusCode)
+        assertEquals("lobby invite not found", (result.body as ErrorResponse).message)
+    }
+
+    @Test
+    fun `invite endpoints map invalid operations to bad request`() {
+        whenever(authService.requireUser("token")).thenReturn(user())
+        whenever(inviteService.createInvite(user(), "lobby-1", "user-b")).thenThrow(
+            IllegalStateException("lobby invite already exists"),
+        )
+
+        val result = controller.createInvite("lobby-1", LobbyInviteRequest("user-b"), "Bearer token")
+
+        assertEquals(HttpStatus.BAD_REQUEST, result.statusCode)
+        assertEquals("lobby invite already exists", (result.body as ErrorResponse).message)
     }
 
     private fun user(userId: String = "user-a", username: String = "Alice") =
@@ -58,6 +122,6 @@ class LobbyInviteControllerTest {
         to = SocialUserDto("user-b", "Bob"),
         status = status,
         createdAt = 1_000L,
-        respondedAt = null,
+        respondedAt = if (status == LobbyInviteStatus.PENDING) null else 2_000L,
     )
 }

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyInviteControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyInviteControllerTest.kt
@@ -1,16 +1,24 @@
 package at.aau.se2.skyjo.controller
 
+import at.aau.se2.skyjo.model.LobbyPlayerInfo
+import at.aau.se2.skyjo.model.LobbyUpdateMessage
 import at.aau.se2.skyjo.model.auth.AuthUserDto
 import at.aau.se2.skyjo.model.auth.ErrorResponse
+import at.aau.se2.skyjo.model.lobby.LobbyPlayer
+import at.aau.se2.skyjo.model.lobby.LobbyState
+import at.aau.se2.skyjo.model.lobby.LobbyStatus
 import at.aau.se2.skyjo.model.social.LobbyInviteDto
 import at.aau.se2.skyjo.model.social.LobbyInviteRequest
 import at.aau.se2.skyjo.model.social.LobbyInviteStatus
 import at.aau.se2.skyjo.model.social.SocialUserDto
 import at.aau.se2.skyjo.service.AuthService
 import at.aau.se2.skyjo.service.LobbyInviteService
+import at.aau.se2.skyjo.service.LobbyService
 import at.aau.se2.skyjo.service.UnauthorizedException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -23,8 +31,9 @@ class LobbyInviteControllerTest {
     private val authService: AuthService = mock()
     private val authSupport = AuthSupport(authService)
     private val inviteService: LobbyInviteService = mock()
+    private val lobbyService: LobbyService = mock()
     private val messagingTemplate: SimpMessageSendingOperations = mock()
-    private val controller = LobbyInviteController(inviteService, authSupport, messagingTemplate)
+    private val controller = LobbyInviteController(inviteService, lobbyService, authSupport, messagingTemplate)
 
     @Test
     fun `createInvite sends invite to user queue`() {
@@ -109,6 +118,42 @@ class LobbyInviteControllerTest {
 
         assertEquals(HttpStatus.BAD_REQUEST, result.statusCode)
         assertEquals("lobby invite already exists", (result.body as ErrorResponse).message)
+    }
+
+    @Test
+    fun `acceptInvite broadcasts updated lobby to topic`() {
+        whenever(authService.requireUser("token")).thenReturn(user("user-b", "Bob"))
+        whenever(inviteService.acceptInvite(user("user-b", "Bob"), "invite-1")).thenReturn(
+            invite(status = LobbyInviteStatus.ACCEPTED),
+        )
+        val lobbyState = LobbyState(
+            lobbyId = "lobby-1",
+            joinCode = "ABC123",
+            players = listOf(
+                LobbyPlayer(sessionId = "user-a", nickname = "Alice", isHost = true),
+                LobbyPlayer(sessionId = "user-b", nickname = "Bob", isHost = false),
+            ),
+            status = LobbyStatus.WAITING,
+            maxPlayers = 6,
+        )
+        whenever(lobbyService.getLobbyById("lobby-1")).thenReturn(lobbyState)
+
+        controller.acceptInvite("invite-1", "Bearer token")
+
+        verify(messagingTemplate).convertAndSend(eq("/topic/lobbies/ABC123"), any<LobbyUpdateMessage>())
+    }
+
+    @Test
+    fun `acceptInvite does not broadcast when lobby not found`() {
+        whenever(authService.requireUser("token")).thenReturn(user("user-b", "Bob"))
+        whenever(inviteService.acceptInvite(user("user-b", "Bob"), "invite-1")).thenReturn(
+            invite(status = LobbyInviteStatus.ACCEPTED),
+        )
+        whenever(lobbyService.getLobbyById("lobby-1")).thenReturn(null)
+
+        controller.acceptInvite("invite-1", "Bearer token")
+
+        verify(messagingTemplate, never()).convertAndSend(any<String>(), any<LobbyUpdateMessage>())
     }
 
     private fun user(userId: String = "user-a", username: String = "Alice") =

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyInviteControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyInviteControllerTest.kt
@@ -1,0 +1,63 @@
+package at.aau.se2.skyjo.controller
+
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.social.LobbyInviteDto
+import at.aau.se2.skyjo.model.social.LobbyInviteRequest
+import at.aau.se2.skyjo.model.social.LobbyInviteStatus
+import at.aau.se2.skyjo.model.social.SocialUserDto
+import at.aau.se2.skyjo.service.AuthService
+import at.aau.se2.skyjo.service.LobbyInviteService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import org.springframework.messaging.simp.SimpMessageSendingOperations
+
+class LobbyInviteControllerTest {
+
+    private val authService: AuthService = mock()
+    private val authSupport = AuthSupport(authService)
+    private val inviteService: LobbyInviteService = mock()
+    private val messagingTemplate: SimpMessageSendingOperations = mock()
+    private val controller = LobbyInviteController(inviteService, authSupport, messagingTemplate)
+
+    @Test
+    fun `createInvite sends invite to user queue`() {
+        whenever(authService.requireUser("token")).thenReturn(user())
+        whenever(inviteService.createInvite(user(), "lobby-1", "user-b")).thenReturn(invite())
+
+        val result = controller.createInvite("lobby-1", LobbyInviteRequest("user-b"), "Bearer token")
+
+        assertEquals(HttpStatus.CREATED, result.statusCode)
+        verify(messagingTemplate).convertAndSendToUser("user-b", "/queue/invites", invite())
+    }
+
+    @Test
+    fun `acceptInvite returns accepted invite`() {
+        whenever(authService.requireUser("token")).thenReturn(user("user-b", "Bob"))
+        whenever(inviteService.acceptInvite(user("user-b", "Bob"), "invite-1")).thenReturn(
+            invite(status = LobbyInviteStatus.ACCEPTED),
+        )
+
+        val result = controller.acceptInvite("invite-1", "Bearer token")
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals(LobbyInviteStatus.ACCEPTED, (result.body as LobbyInviteDto).status)
+    }
+
+    private fun user(userId: String = "user-a", username: String = "Alice") =
+        AuthUserDto(userId = userId, username = username)
+
+    private fun invite(status: LobbyInviteStatus = LobbyInviteStatus.PENDING) = LobbyInviteDto(
+        inviteId = "invite-1",
+        lobbyId = "lobby-1",
+        joinCode = "ABC123",
+        from = SocialUserDto("user-a", "Alice"),
+        to = SocialUserDto("user-b", "Bob"),
+        status = status,
+        createdAt = 1_000L,
+        respondedAt = null,
+    )
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyRestControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyRestControllerTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 import org.springframework.messaging.simp.SimpMessageSendingOperations
@@ -52,6 +53,18 @@ class LobbyRestControllerTest {
     }
 
     @Test
+    fun `leaveLobbyById leaves authenticated lobby and broadcasts update`() {
+        whenever(authService.requireUser("token")).thenReturn(user())
+        whenever(lobbyService.leaveLobby("user-1", "lobby-1")).thenReturn(lobby(players = listOf("Bob")))
+
+        val result = controller.leaveLobbyById("lobby-1", "Bearer token")
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals(listOf("Bob"), (result.body as LobbySummaryResponse).players.map { it.nickname })
+        verify(messagingTemplate).convertAndSend(any<String>(), any<Any>())
+    }
+
+    @Test
     fun `joinLobbyByCode returns not found for invalid code`() {
         whenever(authService.requireUser("token")).thenReturn(user())
         whenever(lobbyService.joinLobby(any(), any())).thenThrow(IllegalStateException("lobby not found"))
@@ -60,6 +73,28 @@ class LobbyRestControllerTest {
 
         assertEquals(HttpStatus.NOT_FOUND, result.statusCode)
         assertEquals("lobby not found", (result.body as ErrorResponse).message)
+    }
+
+    @Test
+    fun `createLobby returns bad request for invalid lobby operation`() {
+        whenever(authService.requireUser("token")).thenReturn(user())
+        whenever(lobbyService.createLobby(user())).thenThrow(IllegalStateException("user is already in a lobby"))
+
+        val result = controller.createLobby("Bearer token")
+
+        assertEquals(HttpStatus.BAD_REQUEST, result.statusCode)
+        assertEquals("user is already in a lobby", (result.body as ErrorResponse).message)
+    }
+
+    @Test
+    fun `currentLobby returns active lobby when one exists`() {
+        whenever(authService.requireUser("token")).thenReturn(user())
+        whenever(lobbyService.getCurrentLobbyForUser("user-1")).thenReturn(lobby())
+
+        val result = controller.currentLobby("Bearer token")
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals("ABC123", (result.body as LobbySummaryResponse).joinCode)
     }
 
     @Test

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyRestControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/LobbyRestControllerTest.kt
@@ -1,0 +1,102 @@
+package at.aau.se2.skyjo.controller
+
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.auth.ErrorResponse
+import at.aau.se2.skyjo.model.lobby.LobbyPlayer
+import at.aau.se2.skyjo.model.lobby.LobbyState
+import at.aau.se2.skyjo.model.lobby.LobbyStatus
+import at.aau.se2.skyjo.model.lobby.LobbySummaryResponse
+import at.aau.se2.skyjo.service.AuthService
+import at.aau.se2.skyjo.service.GameService
+import at.aau.se2.skyjo.service.LobbyService
+import at.aau.se2.skyjo.service.UnauthorizedException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import org.springframework.messaging.simp.SimpMessageSendingOperations
+
+class LobbyRestControllerTest {
+
+    private val lobbyService: LobbyService = mock()
+    private val gameService: GameService = mock()
+    private val messagingTemplate: SimpMessageSendingOperations = mock()
+    private val authService: AuthService = mock()
+    private val authSupport = AuthSupport(authService)
+    private val controller = LobbyController(lobbyService, gameService, messagingTemplate, null, authSupport)
+
+    @Test
+    fun `createLobby creates lobby for authenticated user`() {
+        whenever(authService.requireUser("token")).thenReturn(user())
+        whenever(lobbyService.createLobby(user())).thenReturn(lobby())
+
+        val result = controller.createLobby("Bearer token")
+
+        assertEquals(HttpStatus.CREATED, result.statusCode)
+        assertEquals("ABC123", (result.body as LobbySummaryResponse).joinCode)
+    }
+
+    @Test
+    fun `joinLobbyByCode joins authenticated user`() {
+        whenever(authService.requireUser("token")).thenReturn(user("user-2", "Bob"))
+        whenever(lobbyService.joinLobby(user("user-2", "Bob"), "ABC123")).thenReturn(
+            lobby(players = listOf("Alice", "Bob")),
+        )
+
+        val result = controller.joinLobbyByCode("ABC123", "Bearer token")
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals(listOf("Alice", "Bob"), (result.body as LobbySummaryResponse).players.map { it.nickname })
+    }
+
+    @Test
+    fun `joinLobbyByCode returns not found for invalid code`() {
+        whenever(authService.requireUser("token")).thenReturn(user())
+        whenever(lobbyService.joinLobby(any(), any())).thenThrow(IllegalStateException("lobby not found"))
+
+        val result = controller.joinLobbyByCode("BAD999", "Bearer token")
+
+        assertEquals(HttpStatus.NOT_FOUND, result.statusCode)
+        assertEquals("lobby not found", (result.body as ErrorResponse).message)
+    }
+
+    @Test
+    fun `currentLobby returns no content when user has no lobby`() {
+        whenever(authService.requireUser("token")).thenReturn(user())
+        whenever(lobbyService.getCurrentLobbyForUser("user-1")).thenReturn(null)
+
+        val result = controller.currentLobby("Bearer token")
+
+        assertEquals(HttpStatus.NO_CONTENT, result.statusCode)
+    }
+
+    @Test
+    fun `lobby endpoints return unauthorized when bearer token is invalid`() {
+        whenever(authService.requireUser("bad-token")).thenThrow(UnauthorizedException())
+
+        val result = controller.createLobby("Bearer bad-token")
+
+        assertEquals(HttpStatus.UNAUTHORIZED, result.statusCode)
+        assertEquals("Authentication required", (result.body as ErrorResponse).message)
+    }
+
+    private fun user(userId: String = "user-1", username: String = "Alice") =
+        AuthUserDto(userId = userId, username = username)
+
+    private fun lobby(players: List<String> = listOf("Alice")) = LobbyState(
+        lobbyId = "lobby-1",
+        joinCode = "ABC123",
+        players = players.mapIndexed { index, name ->
+            LobbyPlayer(
+                sessionId = "user-${index + 1}",
+                nickname = name,
+                isHost = index == 0,
+                userId = "user-${index + 1}",
+            )
+        },
+        status = LobbyStatus.WAITING,
+        maxPlayers = 6,
+    )
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/StatsControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/StatsControllerTest.kt
@@ -1,10 +1,12 @@
 package at.aau.se2.skyjo.controller
 
 import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.auth.ErrorResponse
 import at.aau.se2.skyjo.model.stats.LeaderboardEntryDto
 import at.aau.se2.skyjo.model.stats.PlayerStatsDto
 import at.aau.se2.skyjo.service.AuthService
 import at.aau.se2.skyjo.service.StatsService
+import at.aau.se2.skyjo.service.UnauthorizedException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
@@ -29,6 +31,27 @@ class StatsControllerTest {
     }
 
     @Test
+    fun `myStats returns unauthorized when token is invalid`() {
+        whenever(authService.requireUser("bad")).thenThrow(UnauthorizedException())
+
+        val result = controller.myStats("Bearer bad")
+
+        assertEquals(HttpStatus.UNAUTHORIZED, result.statusCode)
+        assertEquals("Authentication required", (result.body as ErrorResponse).message)
+    }
+
+    @Test
+    fun `myStats maps service errors to bad request`() {
+        whenever(authService.requireUser("token")).thenReturn(user())
+        whenever(statsService.getStats("user-a")).thenThrow(IllegalStateException("stats unavailable"))
+
+        val result = controller.myStats("Bearer token")
+
+        assertEquals(HttpStatus.BAD_REQUEST, result.statusCode)
+        assertEquals("stats unavailable", (result.body as ErrorResponse).message)
+    }
+
+    @Test
     fun `leaderboard returns ranked entries`() {
         whenever(statsService.leaderboard(50)).thenReturn(
             listOf(LeaderboardEntryDto(rank = 1, userId = "user-a", username = "Alice", averageScore = 10.0, wins = 1, gamesPlayed = 2, bestScore = 8, totalScore = 20)),
@@ -38,6 +61,16 @@ class StatsControllerTest {
 
         assertEquals(HttpStatus.OK, result.statusCode)
         assertEquals(1, (result.body as List<*>).filterIsInstance<LeaderboardEntryDto>().single().rank)
+    }
+
+    @Test
+    fun `leaderboard passes explicit limit to service`() {
+        whenever(statsService.leaderboard(10)).thenReturn(emptyList())
+
+        val result = controller.leaderboard(limit = 10)
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals(emptyList<LeaderboardEntryDto>(), result.body)
     }
 
     private fun user() = AuthUserDto("user-a", "Alice")

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/StatsControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/StatsControllerTest.kt
@@ -1,0 +1,54 @@
+package at.aau.se2.skyjo.controller
+
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.stats.LeaderboardEntryDto
+import at.aau.se2.skyjo.model.stats.PlayerStatsDto
+import at.aau.se2.skyjo.service.AuthService
+import at.aau.se2.skyjo.service.StatsService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+
+class StatsControllerTest {
+
+    private val authService: AuthService = mock()
+    private val statsService: StatsService = mock()
+    private val controller = StatsController(statsService, AuthSupport(authService))
+
+    @Test
+    fun `myStats returns authenticated user stats`() {
+        whenever(authService.requireUser("token")).thenReturn(user())
+        whenever(statsService.getStats("user-a")).thenReturn(stats())
+
+        val result = controller.myStats("Bearer token")
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals("Alice", (result.body as PlayerStatsDto).username)
+    }
+
+    @Test
+    fun `leaderboard returns ranked entries`() {
+        whenever(statsService.leaderboard(50)).thenReturn(
+            listOf(LeaderboardEntryDto(rank = 1, userId = "user-a", username = "Alice", averageScore = 10.0, wins = 1, gamesPlayed = 2, bestScore = 8, totalScore = 20)),
+        )
+
+        val result = controller.leaderboard(limit = null)
+
+        assertEquals(HttpStatus.OK, result.statusCode)
+        assertEquals(1, (result.body as List<*>).filterIsInstance<LeaderboardEntryDto>().single().rank)
+    }
+
+    private fun user() = AuthUserDto("user-a", "Alice")
+
+    private fun stats() = PlayerStatsDto(
+        userId = "user-a",
+        username = "Alice",
+        gamesPlayed = 0,
+        wins = 0,
+        totalScore = 0,
+        bestScore = null,
+        averageScore = 0.0,
+    )
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/event/WebSocketEvebtListenerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/event/WebSocketEvebtListenerTest.kt
@@ -110,6 +110,8 @@ class WebSocketEventListenerTest {
 
             // Mock für den aktualisierten State nach dem Verlassen
             val updatedState = mockk<LobbyState> {
+                every { lobbyId } returns null
+                every { joinCode } returns null
                 every { players } returns emptyList()
                 every { status } returns mockk() // Nimmt dein LobbyStatus Enum
                 every { maxPlayers } returns 4

--- a/src/test/kotlin/at/aau/se2/skyjo/event/WebSocketEvebtListenerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/event/WebSocketEvebtListenerTest.kt
@@ -25,6 +25,9 @@ class WebSocketEventListenerTest {
     @MockK
     lateinit var lobbyService: LobbyService
 
+    @RelaxedMockK
+    lateinit var authService: AuthService
+
     private lateinit var listener: WebSocketEventListener
 
     @MockK
@@ -32,7 +35,7 @@ class WebSocketEventListenerTest {
 
     @BeforeEach
     fun setUp() {
-        listener = WebSocketEventListener(messagingTemplate, lobbyService, gameService = null)
+        listener = WebSocketEventListener(messagingTemplate, lobbyService, gameService = null, authService = authService)
     }
 
     private val playerId = "player-123"
@@ -51,6 +54,7 @@ class WebSocketEventListenerTest {
             listener.handleWebSocketConnectListener(event)
 
             verify { event.user }
+            verify { authService.markUserConnected(playerId) }
         }
 
         @Test
@@ -89,6 +93,7 @@ class WebSocketEventListenerTest {
 
             listener.handleWebSocketDisconnectListener(event)
 
+            verify { authService.markUserDisconnected(playerId) }
             verify { lobbyService.isPlayerInLobby(playerId) }
             verify(exactly = 0) { lobbyService.leave(any()) }
             verify { messagingTemplate wasNot Called }

--- a/src/test/kotlin/at/aau/se2/skyjo/event/WebSocketEvebtListenerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/event/WebSocketEvebtListenerTest.kt
@@ -28,6 +28,9 @@ class WebSocketEventListenerTest {
     @RelaxedMockK
     lateinit var authService: AuthService
 
+    @MockK
+    lateinit var gameService: GameService
+
     private lateinit var listener: WebSocketEventListener
 
     @MockK
@@ -48,13 +51,29 @@ class WebSocketEventListenerTest {
             val event = mockk<SessionConnectedEvent>()
             every { event.user } returns principal
             every { principal.name } returns playerId
+            every { lobbyService.getCurrentLobbyForUser(playerId) } returns null
 
             // Ausführung (Wir testen hier primär, dass keine Exception fliegt,
             // da die Methode nur loggt und keinen State ändert)
             listener.handleWebSocketConnectListener(event)
 
             verify { event.user }
-            verify { authService.markUserConnected(playerId) }
+            verify { authService.markUserConnected(playerId, null) }
+        }
+
+        @Test
+        fun `markiert Verbindung mit aktueller Lobby wenn User in Join-Code Lobby ist`() {
+            val event = mockk<SessionConnectedEvent>()
+            every { event.user } returns principal
+            every { principal.name } returns playerId
+            every { lobbyService.getCurrentLobbyForUser(playerId) } returns LobbyState(
+                lobbyId = "lobby-1",
+                joinCode = "ABC123",
+            )
+
+            listener.handleWebSocketConnectListener(event)
+
+            verify { authService.markUserConnected(playerId, "lobby-1") }
         }
 
         @Test
@@ -97,6 +116,36 @@ class WebSocketEventListenerTest {
             verify { lobbyService.isPlayerInLobby(playerId) }
             verify(exactly = 0) { lobbyService.leave(any()) }
             verify { messagingTemplate wasNot Called }
+        }
+
+        @Test
+        fun `sendet Disconnect Update fuer das tatsaechliche Spiel des Spielers`() {
+            val event = mockk<SessionDisconnectEvent>()
+            val listenerWithGame = WebSocketEventListener(messagingTemplate, lobbyService, gameService, authService)
+            val gameState = GameUpdateMessage(
+                phase = at.aau.se2.skyjo.game.model.GamePhase.AWAITING_DRAW,
+                currentPlayerId = playerId,
+                players = emptyList(),
+                discardTopCard = null,
+                drawnCard = null,
+                roundResult = null,
+                roundNumber = 1,
+                totalScores = emptyList(),
+                gameOver = false,
+                gameId = "game-1",
+                lobbyId = "lobby-1",
+                disconnectedPlayers = listOf("Alice"),
+            )
+            every { event.user } returns principal
+            every { principal.name } returns playerId
+            every { gameService.markPlayerDisconnected(playerId) } returns gameState
+            every { lobbyService.isPlayerInLobby(playerId) } returns false
+
+            listenerWithGame.handleWebSocketDisconnectListener(event)
+
+            verify { gameService.markPlayerDisconnected(playerId) }
+            verify(exactly = 0) { gameService.getCurrentState() }
+            verify { messagingTemplate.convertAndSend("/topic/games/game-1", gameState) }
         }
 
         @Test

--- a/src/test/kotlin/at/aau/se2/skyjo/event/WebSocketEvebtListenerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/event/WebSocketEvebtListenerTest.kt
@@ -109,12 +109,14 @@ class WebSocketEventListenerTest {
 
             // Spieler ist nicht in der Lobby
             every { lobbyService.isPlayerInLobby(playerId) } returns false
+            every { lobbyService.getCurrentLobbyForUser(playerId) } returns null
 
             listener.handleWebSocketDisconnectListener(event)
 
             verify { authService.markUserDisconnected(playerId) }
             verify { lobbyService.isPlayerInLobby(playerId) }
             verify(exactly = 0) { lobbyService.leave(any()) }
+            verify(exactly = 0) { lobbyService.leaveLobby(any(), any()) }
             verify { messagingTemplate wasNot Called }
         }
 
@@ -140,6 +142,7 @@ class WebSocketEventListenerTest {
             every { principal.name } returns playerId
             every { gameService.markPlayerDisconnected(playerId) } returns gameState
             every { lobbyService.isPlayerInLobby(playerId) } returns false
+            every { lobbyService.getCurrentLobbyForUser(playerId) } returns null
 
             listenerWithGame.handleWebSocketDisconnectListener(event)
 
@@ -166,6 +169,7 @@ class WebSocketEventListenerTest {
                 every { maxPlayers } returns 4
             }
             every { lobbyService.leave(playerId) } returns updatedState
+            every { lobbyService.getCurrentLobbyForUser(playerId) } returns null
 
             listener.handleWebSocketDisconnectListener(event)
 
@@ -177,6 +181,73 @@ class WebSocketEventListenerTest {
                     any<LobbyUpdateMessage>()
                 )
             }
+        }
+
+        @Test
+        fun `authenticated user is removed from authenticated lobby on disconnect`() {
+            val event = mockk<SessionDisconnectEvent>()
+            every { event.user } returns principal
+            every { principal.name } returns playerId
+            every { lobbyService.isPlayerInLobby(playerId) } returns false
+
+            val authenticatedLobby = LobbyState(
+                lobbyId = "lobby-1",
+                joinCode = "ABC123",
+                players = listOf(
+                    LobbyPlayer(sessionId = playerId, nickname = "Alice", isHost = true, userId = playerId),
+                ),
+                status = LobbyStatus.WAITING,
+                maxPlayers = 6,
+            )
+            val updatedLobby = authenticatedLobby.copy(players = emptyList(), status = LobbyStatus.CLOSED)
+            every { lobbyService.getCurrentLobbyForUser(playerId) } returns authenticatedLobby
+            every { lobbyService.leaveLobby(playerId, "lobby-1") } returns updatedLobby
+
+            listener.handleWebSocketDisconnectListener(event)
+
+            verify { lobbyService.leaveLobby(playerId, "lobby-1") }
+            verify { messagingTemplate.convertAndSend("/topic/lobbies/ABC123", any<LobbyUpdateMessage>()) }
+        }
+
+        @Test
+        fun `no authenticated lobby action when getCurrentLobbyForUser returns null`() {
+            val event = mockk<SessionDisconnectEvent>()
+            every { event.user } returns principal
+            every { principal.name } returns playerId
+            every { lobbyService.isPlayerInLobby(playerId) } returns false
+            every { lobbyService.getCurrentLobbyForUser(playerId) } returns null
+
+            listener.handleWebSocketDisconnectListener(event)
+
+            verify(exactly = 0) { lobbyService.leaveLobby(any(), any()) }
+        }
+
+        @Test
+        fun `host transfer broadcast is sent after authenticated host disconnects`() {
+            val event = mockk<SessionDisconnectEvent>()
+            every { event.user } returns principal
+            every { principal.name } returns playerId
+            every { lobbyService.isPlayerInLobby(playerId) } returns false
+
+            val authenticatedLobby = LobbyState(
+                lobbyId = "lobby-1",
+                joinCode = "XYZ789",
+                players = listOf(
+                    LobbyPlayer(sessionId = playerId, nickname = "Host", isHost = true, userId = playerId),
+                    LobbyPlayer(sessionId = "other", nickname = "Guest", isHost = false, userId = "other"),
+                ),
+                status = LobbyStatus.WAITING,
+                maxPlayers = 6,
+            )
+            val updatedLobby = authenticatedLobby.copy(
+                players = listOf(LobbyPlayer(sessionId = "other", nickname = "Guest", isHost = true, userId = "other")),
+            )
+            every { lobbyService.getCurrentLobbyForUser(playerId) } returns authenticatedLobby
+            every { lobbyService.leaveLobby(playerId, "lobby-1") } returns updatedLobby
+
+            listener.handleWebSocketDisconnectListener(event)
+
+            verify { messagingTemplate.convertAndSend("/topic/lobbies/XYZ789", any<LobbyUpdateMessage>()) }
         }
     }
 }

--- a/src/test/kotlin/at/aau/se2/skyjo/persistence/AuthRepositoryTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/persistence/AuthRepositoryTest.kt
@@ -1,0 +1,125 @@
+package at.aau.se2.skyjo.persistence
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
+
+class AuthRepositoryTest {
+
+    private lateinit var repo: AuthRepository
+
+    @BeforeEach
+    fun setUp() {
+        val dataSource = SingleConnectionDataSource("jdbc:sqlite::memory:", true)
+        val jdbc = JdbcTemplate(dataSource)
+        repo = AuthRepository(jdbc)
+        repo.initSchema()
+    }
+
+    @Test
+    fun `usernames are unique case-insensitively`() {
+        repo.createUser(
+            userId = "user-1",
+            username = "Alice",
+            passwordHash = "bcrypt-hash",
+            now = 1_000L,
+        )
+
+        val duplicateError = assertThrows<Exception> {
+            repo.createUser(
+                userId = "user-2",
+                username = "alice",
+                passwordHash = "other-hash",
+                now = 2_000L,
+            )
+        }
+
+        assertTrue(duplicateError.message.orEmpty().contains("UNIQUE", ignoreCase = true))
+        val user = repo.findUserByUsername("ALICE")
+        assertEquals("user-1", user?.userId)
+        assertEquals("Alice", user?.username)
+        assertEquals("bcrypt-hash", user?.passwordHash)
+    }
+
+    @Test
+    fun `expired sessions are not returned`() {
+        repo.createUser("user-1", "Alice", "hash", now = 1_000L)
+        repo.createSession(
+            tokenHash = "token-hash",
+            userId = "user-1",
+            createdAt = 1_000L,
+            expiresAt = 2_000L,
+        )
+
+        assertNull(repo.findActiveSession("token-hash", now = 2_001L))
+    }
+
+    @Test
+    fun `revoked sessions are not returned`() {
+        repo.createUser("user-1", "Alice", "hash", now = 1_000L)
+        repo.createSession("token-hash", "user-1", createdAt = 1_000L, expiresAt = 10_000L)
+
+        repo.revokeSession("token-hash", now = 2_000L)
+
+        assertNull(repo.findActiveSession("token-hash", now = 2_001L))
+    }
+
+    @Test
+    fun `active session can be touched and resolved`() {
+        repo.createUser("user-1", "Alice", "hash", now = 1_000L)
+        repo.createSession("token-hash", "user-1", createdAt = 1_000L, expiresAt = 10_000L)
+
+        repo.touchSession("token-hash", now = 3_000L)
+
+        val session = repo.findActiveSession("token-hash", now = 3_001L)
+        assertEquals("token-hash", session?.tokenHash)
+        assertEquals("user-1", session?.userId)
+        assertEquals(3_000L, session?.lastSeen)
+    }
+
+    @Test
+    fun `websocket ticket can be consumed once only`() {
+        repo.createUser("user-1", "Alice", "hash", now = 1_000L)
+        repo.createWebSocketTicket(
+            ticketHash = "ticket-hash",
+            userId = "user-1",
+            createdAt = 1_000L,
+            expiresAt = 2_000L,
+        )
+
+        val consumed = repo.consumeWebSocketTicket("ticket-hash", now = 1_500L)
+        val consumedAgain = repo.consumeWebSocketTicket("ticket-hash", now = 1_501L)
+
+        assertEquals("user-1", consumed?.userId)
+        assertNull(consumedAgain)
+    }
+
+    @Test
+    fun `expired websocket ticket cannot be consumed`() {
+        repo.createUser("user-1", "Alice", "hash", now = 1_000L)
+        repo.createWebSocketTicket("ticket-hash", "user-1", createdAt = 1_000L, expiresAt = 2_000L)
+
+        assertNull(repo.consumeWebSocketTicket("ticket-hash", now = 2_001L))
+    }
+
+    @Test
+    fun `presence can be stored and cleared`() {
+        repo.createUser("user-1", "Alice", "hash", now = 1_000L)
+
+        repo.setPresence(userId = "user-1", connected = true, currentLobbyId = "lobby-1", now = 2_000L)
+        val online = repo.getPresence("user-1")
+        repo.setPresence(userId = "user-1", connected = false, currentLobbyId = null, now = 3_000L)
+        val offline = repo.getPresence("user-1")
+
+        assertTrue(online?.connected == true)
+        assertEquals("lobby-1", online?.currentLobbyId)
+        assertFalse(offline?.connected == true)
+        assertNull(offline?.currentLobbyId)
+    }
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/persistence/FriendRepositoryTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/persistence/FriendRepositoryTest.kt
@@ -1,0 +1,69 @@
+package at.aau.se2.skyjo.persistence
+
+import at.aau.se2.skyjo.model.social.FriendRequestStatus
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
+
+class FriendRepositoryTest {
+
+    private lateinit var authRepository: AuthRepository
+    private lateinit var repository: FriendRepository
+
+    @BeforeEach
+    fun setUp() {
+        val dataSource = SingleConnectionDataSource("jdbc:sqlite::memory:", true)
+        val jdbc = JdbcTemplate(dataSource)
+        authRepository = AuthRepository(jdbc)
+        repository = FriendRepository(jdbc)
+        authRepository.initSchema()
+        repository.initSchema()
+        createUser("user-a", "Alice")
+        createUser("user-b", "Bob")
+        createUser("user-c", "Cara")
+    }
+
+    @Test
+    fun `searchUsers excludes current user and matches username case-insensitively`() {
+        val results = repository.searchUsers(query = "bo", currentUserId = "user-a", limit = 10)
+
+        assertEquals(listOf("Bob"), results.map { it.username })
+    }
+
+    @Test
+    fun `friend requests can be listed incoming and outgoing`() {
+        repository.createFriendRequest("request-1", fromUserId = "user-a", toUserId = "user-b", now = 1_000L)
+
+        val incoming = repository.listIncomingRequests("user-b")
+        val outgoing = repository.listOutgoingRequests("user-a")
+
+        assertEquals("request-1", incoming.single().requestId)
+        assertEquals(FriendRequestStatus.PENDING, incoming.single().status)
+        assertEquals("request-1", outgoing.single().requestId)
+    }
+
+    @Test
+    fun `listFriends includes username presence and current lobby`() {
+        repository.createFriendship("user-a", "user-b", now = 1_000L)
+        repository.createFriendship("user-b", "user-a", now = 1_000L)
+        authRepository.setPresence("user-b", connected = true, currentLobbyId = "lobby-1", now = 2_000L)
+
+        val friends = repository.listFriends("user-a")
+
+        assertEquals("Bob", friends.single().username)
+        assertTrue(friends.single().online)
+        assertEquals("lobby-1", friends.single().currentLobbyId)
+    }
+
+    private fun createUser(userId: String, username: String) {
+        authRepository.createUser(
+            userId = userId,
+            username = username,
+            passwordHash = "hash-$userId",
+            now = 1L,
+        )
+    }
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/persistence/GameRepositoryTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/persistence/GameRepositoryTest.kt
@@ -43,6 +43,19 @@ class GameRepositoryTest {
     }
 
     @Test
+    fun `saveGame and loadActiveGames return multiple active games with lobby ids`() {
+        repo.saveGame("game-1", "lobby-1", GameState(phase = GamePhase.AWAITING_DRAW))
+        repo.saveGame("game-2", "lobby-2", GameState(phase = GamePhase.AWAITING_REPLACEMENT))
+        repo.saveGame("game-3", "lobby-3", GameState(phase = GamePhase.NOT_STARTED))
+
+        val loaded = repo.loadActiveGames()
+
+        assertEquals(setOf("game-1", "game-2"), loaded.map { it.gameId }.toSet())
+        assertEquals("lobby-1", loaded.first { it.gameId == "game-1" }.lobbyId)
+        assertEquals(GamePhase.AWAITING_REPLACEMENT, loaded.first { it.gameId == "game-2" }.state.phase)
+    }
+
+    @Test
     fun `loadActiveGame ignores NOT_STARTED games`() {
         val state = GameState(phase = GamePhase.NOT_STARTED)
         repo.saveGame("game-not-started", state)

--- a/src/test/kotlin/at/aau/se2/skyjo/persistence/GameRepositoryTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/persistence/GameRepositoryTest.kt
@@ -47,6 +47,8 @@ class GameRepositoryTest {
         repo.saveGame("game-1", "lobby-1", GameState(phase = GamePhase.AWAITING_DRAW))
         repo.saveGame("game-2", "lobby-2", GameState(phase = GamePhase.AWAITING_REPLACEMENT))
         repo.saveGame("game-3", "lobby-3", GameState(phase = GamePhase.NOT_STARTED))
+        repo.saveGame("game-4", "lobby-4", GameState(phase = GamePhase.ROUND_FINISHED))
+        repo.saveGame("game-5", "lobby-5", GameState(phase = GamePhase.AWAITING_DRAW), completed = true)
 
         val loaded = repo.loadActiveGames()
 
@@ -59,6 +61,14 @@ class GameRepositoryTest {
     fun `loadActiveGame ignores NOT_STARTED games`() {
         val state = GameState(phase = GamePhase.NOT_STARTED)
         repo.saveGame("game-not-started", state)
+
+        assertNull(repo.loadActiveGame())
+    }
+
+    @Test
+    fun `loadActiveGame ignores ROUND_FINISHED games`() {
+        val state = GameState(phase = GamePhase.ROUND_FINISHED)
+        repo.saveGame("game-finished-round", state)
 
         assertNull(repo.loadActiveGame())
     }
@@ -115,6 +125,7 @@ class GameRepositoryTest {
 
     @Test
     fun `savePlayerSession creates new session`() {
+        repo.saveGame("game-1", GameState(phase = GamePhase.AWAITING_DRAW))
         repo.savePlayerSession("player-1", "game-1", connected = true)
 
         assertEquals("game-1", repo.getPlayerGame("player-1"))
@@ -122,6 +133,8 @@ class GameRepositoryTest {
 
     @Test
     fun `savePlayerSession updates existing session`() {
+        repo.saveGame("game-1", GameState(phase = GamePhase.AWAITING_DRAW))
+        repo.saveGame("game-2", GameState(phase = GamePhase.AWAITING_REPLACEMENT))
         repo.savePlayerSession("player-1", "game-1", connected = true)
         repo.savePlayerSession("player-1", "game-2", connected = false)
 
@@ -135,10 +148,43 @@ class GameRepositoryTest {
 
     @Test
     fun `markDisconnected updates existing session`() {
+        repo.saveGame("game-1", GameState(phase = GamePhase.AWAITING_DRAW))
         repo.savePlayerSession("player-1", "game-1", connected = true)
         repo.markDisconnected("player-1")
 
         assertEquals("game-1", repo.getPlayerGame("player-1"))
+    }
+
+    @Test
+    fun `getPlayerGame ignores inactive games`() {
+        repo.saveGame("game-not-started", GameState(phase = GamePhase.NOT_STARTED))
+        repo.saveGame("game-round-finished", GameState(phase = GamePhase.ROUND_FINISHED))
+        repo.saveGame("game-completed", GameState(phase = GamePhase.AWAITING_DRAW), completed = true)
+
+        repo.savePlayerSession("player-1", "game-not-started", connected = true)
+        repo.savePlayerSession("player-2", "game-round-finished", connected = true)
+        repo.savePlayerSession("player-3", "game-completed", connected = true)
+        repo.savePlayerSession("player-4", "game-missing", connected = true)
+
+        assertNull(repo.getPlayerGame("player-1"))
+        assertNull(repo.getPlayerGame("player-2"))
+        assertNull(repo.getPlayerGame("player-3"))
+        assertNull(repo.getPlayerGame("player-4"))
+    }
+
+    @Test
+    fun `deletePlayerSessionsForGame removes completed game sessions`() {
+        repo.saveGame("game-1", GameState(phase = GamePhase.AWAITING_DRAW))
+        repo.saveGame("game-2", GameState(phase = GamePhase.AWAITING_DRAW))
+        repo.savePlayerSession("player-1", "game-1", connected = true)
+        repo.savePlayerSession("player-2", "game-1", connected = true)
+        repo.savePlayerSession("player-3", "game-2", connected = true)
+
+        repo.deletePlayerSessionsForGame("game-1")
+
+        assertNull(repo.getPlayerGame("player-1"))
+        assertNull(repo.getPlayerGame("player-2"))
+        assertEquals("game-2", repo.getPlayerGame("player-3"))
     }
 
     @Test

--- a/src/test/kotlin/at/aau/se2/skyjo/persistence/LobbyInviteRepositoryTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/persistence/LobbyInviteRepositoryTest.kt
@@ -1,0 +1,58 @@
+package at.aau.se2.skyjo.persistence
+
+import at.aau.se2.skyjo.model.social.LobbyInviteStatus
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
+
+class LobbyInviteRepositoryTest {
+
+    private lateinit var authRepository: AuthRepository
+    private lateinit var lobbyRepository: LobbyRepository
+    private lateinit var repository: LobbyInviteRepository
+
+    @BeforeEach
+    fun setUp() {
+        val dataSource = SingleConnectionDataSource("jdbc:sqlite::memory:", true)
+        val jdbc = JdbcTemplate(dataSource)
+        authRepository = AuthRepository(jdbc)
+        lobbyRepository = LobbyRepository(jdbc)
+        repository = LobbyInviteRepository(jdbc)
+        authRepository.initSchema()
+        lobbyRepository.initSchema()
+        repository.initSchema()
+        authRepository.createUser("user-a", "Alice", "hash-a", now = 1L)
+        authRepository.createUser("user-b", "Bob", "hash-b", now = 1L)
+        lobbyRepository.createLobby("lobby-1", "ABC123", "user-a", maxPlayers = 6, now = 1_000L)
+    }
+
+    @Test
+    fun `createInvite can be listed by recipient`() {
+        repository.createInvite(
+            inviteId = "invite-1",
+            lobbyId = "lobby-1",
+            joinCode = "ABC123",
+            fromUserId = "user-a",
+            toUserId = "user-b",
+            now = 1_000L,
+        )
+
+        val invites = repository.listPendingInvitesForUser("user-b")
+
+        assertEquals("invite-1", invites.single().inviteId)
+        assertEquals("ABC123", invites.single().joinCode)
+        assertEquals(LobbyInviteStatus.PENDING, invites.single().status)
+    }
+
+    @Test
+    fun `updateInviteStatus stores response timestamp`() {
+        repository.createInvite("invite-1", "lobby-1", "ABC123", "user-a", "user-b", now = 1_000L)
+
+        val updated = repository.updateInviteStatus("invite-1", LobbyInviteStatus.ACCEPTED, respondedAt = 2_000L)
+
+        assertEquals(LobbyInviteStatus.ACCEPTED, updated!!.status)
+        assertEquals(2_000L, updated.respondedAt)
+    }
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/persistence/LobbyRepositoryTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/persistence/LobbyRepositoryTest.kt
@@ -1,0 +1,61 @@
+package at.aau.se2.skyjo.persistence
+
+import at.aau.se2.skyjo.model.lobby.LobbyStatus
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
+
+class LobbyRepositoryTest {
+
+    private lateinit var repo: LobbyRepository
+
+    @BeforeEach
+    fun setUp() {
+        val dataSource = SingleConnectionDataSource("jdbc:sqlite::memory:", true)
+        val jdbc = JdbcTemplate(dataSource)
+        repo = LobbyRepository(jdbc)
+        repo.initSchema()
+    }
+
+    @Test
+    fun `creates and loads lobby by join code`() {
+        repo.createLobby("lobby-1", "ABC123", "user-1", maxPlayers = 6, now = 1_000L)
+
+        val lobby = repo.findLobbyByJoinCode("abc123")
+
+        assertEquals("lobby-1", lobby?.lobbyId)
+        assertEquals("ABC123", lobby?.joinCode)
+        assertEquals("user-1", lobby?.hostUserId)
+        assertEquals(LobbyStatus.WAITING, lobby?.status)
+    }
+
+    @Test
+    fun `stores lobby members and finds current lobby for user`() {
+        repo.createLobby("lobby-1", "ABC123", "user-1", maxPlayers = 6, now = 1_000L)
+        repo.upsertMember("lobby-1", "user-1", "Alice", isHost = true, joinedAt = 1_000L)
+        repo.upsertMember("lobby-1", "user-2", "Bob", isHost = false, joinedAt = 2_000L)
+
+        val members = repo.listMembers("lobby-1")
+        val currentLobby = repo.findCurrentLobbyForUser("user-2")
+
+        assertEquals(listOf("Alice", "Bob"), members.map { it.username })
+        assertEquals("lobby-1", currentLobby?.lobbyId)
+    }
+
+    @Test
+    fun `removing member and closing lobby updates persisted state`() {
+        repo.createLobby("lobby-1", "ABC123", "user-1", maxPlayers = 6, now = 1_000L)
+        repo.upsertMember("lobby-1", "user-1", "Alice", isHost = true, joinedAt = 1_000L)
+
+        repo.removeMember("lobby-1", "user-1")
+        repo.updateLobbyStatus("lobby-1", LobbyStatus.CLOSED, now = 2_000L)
+
+        assertTrue(repo.listMembers("lobby-1").isEmpty())
+        assertNull(repo.findCurrentLobbyForUser("user-1"))
+        assertEquals(LobbyStatus.CLOSED, repo.findLobbyById("lobby-1")?.status)
+    }
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/persistence/StatsRepositoryTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/persistence/StatsRepositoryTest.kt
@@ -1,0 +1,61 @@
+package at.aau.se2.skyjo.persistence
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
+
+class StatsRepositoryTest {
+
+    private lateinit var authRepository: AuthRepository
+    private lateinit var repository: StatsRepository
+
+    @BeforeEach
+    fun setUp() {
+        val dataSource = SingleConnectionDataSource("jdbc:sqlite::memory:", true)
+        val jdbc = JdbcTemplate(dataSource)
+        authRepository = AuthRepository(jdbc)
+        repository = StatsRepository(jdbc)
+        authRepository.initSchema()
+        repository.initSchema()
+        createUser("user-a", "Alice")
+        createUser("user-b", "Bob")
+        createUser("user-c", "Cara")
+    }
+
+    @Test
+    fun `recordResult inserts and updates player stats`() {
+        repository.recordResult("user-a", totalScore = 20, won = true, now = 1_000L)
+        repository.recordResult("user-a", totalScore = 30, won = false, now = 2_000L)
+
+        val stats = repository.findStats("user-a")!!
+
+        assertEquals(2, stats.gamesPlayed)
+        assertEquals(1, stats.wins)
+        assertEquals(50, stats.totalScore)
+        assertEquals(20, stats.bestScore)
+    }
+
+    @Test
+    fun `leaderboard sorts by lowest average then wins then games`() {
+        repository.recordResult("user-a", totalScore = 20, won = false, now = 1_000L)
+        repository.recordResult("user-b", totalScore = 20, won = true, now = 1_000L)
+        repository.recordResult("user-c", totalScore = 10, won = false, now = 1_000L)
+        repository.recordResult("user-c", totalScore = 30, won = false, now = 1_000L)
+
+        val leaderboard = repository.leaderboard(limit = 10)
+
+        assertEquals(listOf("Bob", "Cara", "Alice"), leaderboard.map { it.username })
+    }
+
+    @Test
+    fun `findStats returns null for users without games`() {
+        assertNull(repository.findStats("user-a"))
+    }
+
+    private fun createUser(userId: String, username: String) {
+        authRepository.createUser(userId, username, "hash-$userId", now = 1L)
+    }
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/service/AuthServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/AuthServiceTest.kt
@@ -144,6 +144,19 @@ class AuthServiceTest {
     }
 
     @Test
+    fun `presence can be marked online and offline`() {
+        val registered = service.register(username = "Alice", password = "password123")
+
+        service.markUserConnected(registered.user.userId)
+        val online = repo.getPresence(registered.user.userId)
+        service.markUserDisconnected(registered.user.userId)
+        val offline = repo.getPresence(registered.user.userId)
+
+        assertTrue(online?.connected == true)
+        assertFalse(offline?.connected == true)
+    }
+
+    @Test
     fun `generated default tokens are url safe and long enough`() {
         val generated = RandomSecureTokenGenerator().generateToken()
 

--- a/src/test/kotlin/at/aau/se2/skyjo/service/AuthServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/AuthServiceTest.kt
@@ -1,0 +1,155 @@
+package at.aau.se2.skyjo.service
+
+import at.aau.se2.skyjo.persistence.AuthRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+
+class AuthServiceTest {
+
+    private lateinit var repo: AuthRepository
+    private lateinit var service: AuthService
+    private var now = 1_000L
+
+    @BeforeEach
+    fun setUp() {
+        val dataSource = SingleConnectionDataSource("jdbc:sqlite::memory:", true)
+        repo = AuthRepository(JdbcTemplate(dataSource))
+        repo.initSchema()
+        service = AuthService(
+            repository = repo,
+            passwordEncoder = BCryptPasswordEncoder(),
+            nowProvider = { now },
+            tokenGenerator = object : SecureTokenGenerator {
+                private var next = 0
+                override fun generateToken(): String {
+                    next += 1
+                    return "secure-token-value-$next-with-at-least-32-characters"
+                }
+            },
+        )
+    }
+
+    @Test
+    fun `register stores bcrypt hash and returns session token`() {
+        val response = service.register(username = "Alice_1", password = "password123")
+
+        val storedUser = repo.findUserByUsername("alice_1")
+        assertNotNull(storedUser)
+        assertEquals("Alice_1", storedUser?.username)
+        assertNotEquals("password123", storedUser?.passwordHash)
+        assertTrue(storedUser?.passwordHash.orEmpty().startsWith("$2"))
+        assertEquals("secure-token-value-1-with-at-least-32-characters", response.token)
+        assertEquals("Alice_1", response.user.username)
+        assertNull(repo.findActiveSession(response.token, now))
+    }
+
+    @Test
+    fun `register rejects invalid username and short password`() {
+        assertThrows<InvalidAuthInputException> {
+            service.register(username = "al", password = "password123")
+        }
+        assertThrows<InvalidAuthInputException> {
+            service.register(username = "valid_name", password = "short")
+        }
+    }
+
+    @Test
+    fun `register rejects duplicate username case-insensitively`() {
+        service.register(username = "Alice", password = "password123")
+
+        assertThrows<DuplicateUsernameException> {
+            service.register(username = "alice", password = "password123")
+        }
+    }
+
+    @Test
+    fun `login returns generic error for unknown user or wrong password`() {
+        service.register(username = "Alice", password = "password123")
+
+        val wrongPassword = assertThrows<InvalidCredentialsException> {
+            service.login(username = "Alice", password = "wrong-password")
+        }
+        val unknownUser = assertThrows<InvalidCredentialsException> {
+            service.login(username = "Unknown", password = "password123")
+        }
+
+        assertEquals("Invalid username or password", wrongPassword.message)
+        assertEquals("Invalid username or password", unknownUser.message)
+    }
+
+    @Test
+    fun `login returns new token for valid credentials`() {
+        service.register(username = "Alice", password = "password123")
+
+        val login = service.login(username = "alice", password = "password123")
+
+        assertEquals("Alice", login.user.username)
+        assertEquals("secure-token-value-2-with-at-least-32-characters", login.token)
+    }
+
+    @Test
+    fun `requireUser resolves valid token and rejects revoked token`() {
+        val registered = service.register(username = "Alice", password = "password123")
+
+        val user = service.requireUser(registered.token)
+        service.logout(registered.token)
+
+        assertEquals("Alice", user.username)
+        assertThrows<UnauthorizedException> {
+            service.requireUser(registered.token)
+        }
+    }
+
+    @Test
+    fun `session expires after thirty days`() {
+        val registered = service.register(username = "Alice", password = "password123")
+
+        now += AuthService.SESSION_TTL_MILLIS + 1
+
+        assertThrows<UnauthorizedException> {
+            service.requireUser(registered.token)
+        }
+    }
+
+    @Test
+    fun `websocket ticket is short lived and consumed once`() {
+        val registered = service.register(username = "Alice", password = "password123")
+
+        val ticket = service.createWebSocketTicket(registered.token)
+        val consumed = service.consumeWebSocketTicket(ticket.ticket)
+        val consumedAgain = service.consumeWebSocketTicket(ticket.ticket)
+
+        assertEquals(now + AuthService.WEBSOCKET_TICKET_TTL_MILLIS, ticket.expiresAt)
+        assertEquals("Alice", consumed?.username)
+        assertNull(consumedAgain)
+    }
+
+    @Test
+    fun `raw websocket ticket is not stored`() {
+        val registered = service.register(username = "Alice", password = "password123")
+
+        val ticket = service.createWebSocketTicket(registered.token)
+
+        assertNull(repo.consumeWebSocketTicket(ticket.ticket, now))
+    }
+
+    @Test
+    fun `generated default tokens are url safe and long enough`() {
+        val generated = RandomSecureTokenGenerator().generateToken()
+
+        assertTrue(generated.length >= 43)
+        assertFalse(generated.contains("+"))
+        assertFalse(generated.contains("/"))
+        assertFalse(generated.contains("="))
+    }
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/service/FriendServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/FriendServiceTest.kt
@@ -159,6 +159,24 @@ class FriendServiceTest {
     }
 
     @Test
+    fun `listFriendRequests returns INCOMING_REQUEST on from field when current user is recipient`() {
+        service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+
+        val requests = service.listFriendRequests(user("user-b", "Bob"))
+
+        assertEquals(RelationshipStatus.INCOMING_REQUEST, requests.incoming.single().from.relationshipStatus)
+    }
+
+    @Test
+    fun `listFriendRequests returns OUTGOING_REQUEST on to field when current user is sender`() {
+        service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+
+        val requests = service.listFriendRequests(user("user-a", "Alice"))
+
+        assertEquals(RelationshipStatus.OUTGOING_REQUEST, requests.outgoing.single().to.relationshipStatus)
+    }
+
+    @Test
     fun `acceptFriendRequest rejects users that are not the receiver`() {
         val request = service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
 

--- a/src/test/kotlin/at/aau/se2/skyjo/service/FriendServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/FriendServiceTest.kt
@@ -186,6 +186,16 @@ class FriendServiceTest {
     }
 
     @Test
+    fun `sendFriendRequest succeeds after previous request was declined`() {
+        val first = service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+        service.declineFriendRequest(user("user-b", "Bob"), first.requestId)
+
+        val second = service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+
+        assertEquals(FriendRequestStatus.PENDING, second.status)
+    }
+
+    @Test
     fun `declineFriendRequest marks request declined and rejects a second decline`() {
         val request = service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
 

--- a/src/test/kotlin/at/aau/se2/skyjo/service/FriendServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/FriendServiceTest.kt
@@ -54,6 +54,15 @@ class FriendServiceTest {
     }
 
     @Test
+    fun `sendFriendRequest rejects unknown target users`() {
+        val error = assertThrows<IllegalStateException> {
+            service.sendFriendRequest(user("user-a", "Alice"), toUserId = "missing")
+        }
+
+        assertTrue(error.message.orEmpty().contains("user not found"))
+    }
+
+    @Test
     fun `sendFriendRequest creates pending outgoing request`() {
         val request = service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
 
@@ -87,12 +96,88 @@ class FriendServiceTest {
     }
 
     @Test
+    fun `sendFriendRequest rejects duplicate pending request in either direction`() {
+        service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+
+        val sameDirection = assertThrows<IllegalStateException> {
+            service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+        }
+        val reverseDirection = assertThrows<IllegalStateException> {
+            service.sendFriendRequest(user("user-b", "Bob"), toUserId = "user-a")
+        }
+
+        assertTrue(sameDirection.message.orEmpty().contains("already exists"))
+        assertTrue(reverseDirection.message.orEmpty().contains("already exists"))
+    }
+
+    @Test
     fun `searchUsers returns relationship status`() {
         service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
 
         val results = service.searchUsers(user("user-a", "Alice"), query = "b")
 
         assertEquals(RelationshipStatus.OUTGOING_REQUEST, results.single { it.username == "Bob" }.relationshipStatus)
+    }
+
+    @Test
+    fun `searchUsers returns empty result for blank query`() {
+        val results = service.searchUsers(user("user-a", "Alice"), query = "   ")
+
+        assertTrue(results.isEmpty())
+    }
+
+    @Test
+    fun `searchUsers reports incoming friend and no relationship statuses`() {
+        service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+
+        val incoming = service.searchUsers(user("user-b", "Bob"), query = "ali")
+        val none = service.searchUsers(user("user-a", "Alice"), query = "cara")
+
+        assertEquals(RelationshipStatus.INCOMING_REQUEST, incoming.single().relationshipStatus)
+        assertEquals(RelationshipStatus.NONE, none.single().relationshipStatus)
+    }
+
+    @Test
+    fun `searchUsers reports friends after accepted request`() {
+        val request = service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+        service.acceptFriendRequest(user("user-b", "Bob"), request.requestId)
+
+        val results = service.searchUsers(user("user-a", "Alice"), query = "bob")
+
+        assertEquals(RelationshipStatus.FRIENDS, results.single().relationshipStatus)
+    }
+
+    @Test
+    fun `listFriendRequests separates incoming and outgoing requests`() {
+        service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+        service.sendFriendRequest(user("user-c", "Cara"), toUserId = "user-a")
+
+        val requests = service.listFriendRequests(user("user-a", "Alice"))
+
+        assertEquals(listOf("Cara"), requests.incoming.map { it.from.username })
+        assertEquals(listOf("Bob"), requests.outgoing.map { it.to.username })
+    }
+
+    @Test
+    fun `acceptFriendRequest rejects users that are not the receiver`() {
+        val request = service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+
+        assertThrows<UnauthorizedException> {
+            service.acceptFriendRequest(user("user-c", "Cara"), request.requestId)
+        }
+    }
+
+    @Test
+    fun `declineFriendRequest marks request declined and rejects a second decline`() {
+        val request = service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+
+        val declined = service.declineFriendRequest(user("user-b", "Bob"), request.requestId)
+
+        assertEquals(FriendRequestStatus.DECLINED, declined.status)
+        val error = assertThrows<IllegalStateException> {
+            service.declineFriendRequest(user("user-b", "Bob"), request.requestId)
+        }
+        assertTrue(error.message.orEmpty().contains("not pending"))
     }
 
     private fun createUser(userId: String, username: String) {

--- a/src/test/kotlin/at/aau/se2/skyjo/service/FriendServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/FriendServiceTest.kt
@@ -1,0 +1,108 @@
+package at.aau.se2.skyjo.service
+
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.social.FriendRequestStatus
+import at.aau.se2.skyjo.model.social.RelationshipStatus
+import at.aau.se2.skyjo.persistence.AuthRepository
+import at.aau.se2.skyjo.persistence.FriendRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
+
+class FriendServiceTest {
+
+    private lateinit var authRepository: AuthRepository
+    private lateinit var repository: FriendRepository
+    private lateinit var service: FriendService
+
+    @BeforeEach
+    fun setUp() {
+        val dataSource = SingleConnectionDataSource("jdbc:sqlite::memory:", true)
+        val jdbc = JdbcTemplate(dataSource)
+        authRepository = AuthRepository(jdbc)
+        repository = FriendRepository(jdbc)
+        authRepository.initSchema()
+        repository.initSchema()
+        createUser("user-a", "Alice")
+        createUser("user-b", "Bob")
+        createUser("user-c", "Cara")
+        service = FriendService(
+            repository = repository,
+            authRepository = authRepository,
+            requestIdGenerator = object : FriendRequestIdGenerator {
+                private var next = 0
+                override fun generateId(): String {
+                    next += 1
+                    return "request-$next"
+                }
+            },
+            nowProvider = { 1_000L },
+        )
+    }
+
+    @Test
+    fun `sendFriendRequest rejects self requests`() {
+        val error = assertThrows<IllegalStateException> {
+            service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-a")
+        }
+
+        assertTrue(error.message.orEmpty().contains("yourself"))
+    }
+
+    @Test
+    fun `sendFriendRequest creates pending outgoing request`() {
+        val request = service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+
+        assertEquals("request-1", request.requestId)
+        assertEquals(FriendRequestStatus.PENDING, request.status)
+        assertEquals("Alice", request.from.username)
+        assertEquals("Bob", request.to.username)
+    }
+
+    @Test
+    fun `acceptFriendRequest creates reciprocal friendship`() {
+        val request = service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+
+        val accepted = service.acceptFriendRequest(user("user-b", "Bob"), request.requestId)
+
+        assertEquals(FriendRequestStatus.ACCEPTED, accepted.status)
+        assertEquals(listOf("Bob"), service.listFriends(user("user-a", "Alice")).map { it.username })
+        assertEquals(listOf("Alice"), service.listFriends(user("user-b", "Bob")).map { it.username })
+    }
+
+    @Test
+    fun `sendFriendRequest rejects duplicate friendship`() {
+        val request = service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+        service.acceptFriendRequest(user("user-b", "Bob"), request.requestId)
+
+        val error = assertThrows<IllegalStateException> {
+            service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+        }
+
+        assertTrue(error.message.orEmpty().contains("already friends"))
+    }
+
+    @Test
+    fun `searchUsers returns relationship status`() {
+        service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+
+        val results = service.searchUsers(user("user-a", "Alice"), query = "b")
+
+        assertEquals(RelationshipStatus.OUTGOING_REQUEST, results.single { it.username == "Bob" }.relationshipStatus)
+    }
+
+    private fun createUser(userId: String, username: String) {
+        authRepository.createUser(
+            userId = userId,
+            username = username,
+            passwordHash = "hash-$userId",
+            now = 1L,
+        )
+    }
+
+    private fun user(userId: String, username: String) = AuthUserDto(userId = userId, username = username)
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
@@ -131,6 +131,33 @@ class GameServiceTest {
         assertTrue(result.disconnectedPlayers.isEmpty())
     }
 
+    @Test
+    fun `startGame can run separate lobby games with player routing`() {
+        val first = service.startGame("lobby-1", players)
+        val secondPlayers = listOf(
+            LobbyPlayer(sessionId = "session-3", nickname = "Cara", isHost = true, userId = "player3"),
+            LobbyPlayer(sessionId = "session-4", nickname = "Dan", isHost = false, userId = "player4"),
+        )
+
+        val second = service.startGame("lobby-2", secondPlayers)
+
+        assertNotEquals(first.gameId, second.gameId)
+        assertEquals("lobby-1", first.lobbyId)
+        assertEquals("lobby-2", second.lobbyId)
+        assertEquals(first.gameId, service.getCurrentState(player1Id)?.gameId)
+        assertEquals(second.gameId, service.getCurrentState("player3")?.gameId)
+
+        val firstCurrentPlayer = service.getCurrentState(player1Id)!!.currentPlayerId!!
+        val firstAfterAction = service.processAction(
+            firstCurrentPlayer,
+            GameActionMessage(ActionType.DRAW, source = DrawSource.DECK),
+        )
+
+        assertEquals(first.gameId, firstAfterAction.gameId)
+        assertEquals(second.gameId, service.getCurrentState("player3")?.gameId)
+        assertEquals(GamePhase.AWAITING_DRAW, service.getCurrentState("player3")?.phase)
+    }
+
     // ── processAction – error handling ────────────────────────────────────
 
     @Test

--- a/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
@@ -162,6 +162,38 @@ class GameServiceTest {
         assertEquals(GamePhase.AWAITING_DRAW, service.getCurrentState("player3")?.phase)
     }
 
+    @Test
+    fun `markPlayerDisconnected returns disconnected player's own game state`() {
+        val first = service.startGame("lobby-1", players)
+        val secondPlayers = listOf(
+            LobbyPlayer(sessionId = "session-3", nickname = "Cara", isHost = true, userId = "player3"),
+            LobbyPlayer(sessionId = "session-4", nickname = "Dan", isHost = false, userId = "player4"),
+        )
+        val second = service.startGame("lobby-2", secondPlayers)
+
+        val update = service.markPlayerDisconnected(player1Id)
+
+        assertEquals(first.gameId, update?.gameId)
+        assertTrue(update?.disconnectedPlayers?.contains("Alice") == true)
+        assertEquals(second.gameId, service.getCurrentState()?.gameId)
+    }
+
+    @Test
+    fun `reconnectPlayer restores a non-current game by game id and authenticated user id`() {
+        val first = service.startGame("lobby-1", players)
+        val secondPlayers = listOf(
+            LobbyPlayer(sessionId = "session-3", nickname = "Cara", isHost = true, userId = "player3"),
+            LobbyPlayer(sessionId = "session-4", nickname = "Dan", isHost = false, userId = "player4"),
+        )
+        service.startGame("lobby-2", secondPlayers)
+        service.markPlayerDisconnected(player1Id)
+
+        val update = service.reconnectPlayer(player1Id, "Alice", first.gameId!!)
+
+        assertEquals(first.gameId, update?.gameId)
+        assertFalse(update?.disconnectedPlayers?.contains("Alice") == true)
+    }
+
     // ── processAction – error handling ────────────────────────────────────
 
     @Test

--- a/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
@@ -19,11 +19,15 @@ import at.aau.se2.skyjo.model.ActionType
 import at.aau.se2.skyjo.model.GameActionMessage
 import at.aau.se2.skyjo.model.GameConfig
 import at.aau.se2.skyjo.model.lobby.LobbyPlayer
+import at.aau.se2.skyjo.persistence.AuthRepository
+import at.aau.se2.skyjo.persistence.StatsRepository
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import at.aau.se2.skyjo.game.error.InvalidMoveException
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
 
 class GameServiceTest {
 
@@ -910,6 +914,29 @@ class GameServiceTest {
 
         // targetScore = 0 means any score >= 0 triggers game over
         assertTrue(result.gameOver)
+    }
+
+    @Test
+    fun `handleRoundFinished records final stats once when game is over`() {
+        val dataSource = SingleConnectionDataSource("jdbc:sqlite::memory:", true)
+        val jdbc = JdbcTemplate(dataSource)
+        val authRepository = AuthRepository(jdbc)
+        val statsRepository = StatsRepository(jdbc)
+        authRepository.initSchema()
+        statsRepository.initSchema()
+        authRepository.createUser(player1Id, "Alice", "hash-1", now = 1L)
+        authRepository.createUser(player2Id, "Bob", "hash-2", now = 1L)
+        val statsService = StatsService(statsRepository, authRepository, nowProvider = { 1_000L })
+        service = GameService(engine, gameRepository = null, statsService = statsService)
+        service.startGame(players, GameConfig(maxRounds = 1))
+        val gameState = getInternalGameState(service)
+        val finishedState = engine.finishRound(gameState.copy(finisherPlayerId = gameState.currentPlayerId!!))
+
+        service.handleRoundFinished(finishedState)
+        service.handleRoundFinished(finishedState)
+
+        assertEquals(1, statsRepository.findStats(player1Id)?.gamesPlayed)
+        assertEquals(1, statsRepository.findStats(player2Id)?.gamesPlayed)
     }
 
     // ── getCurrentState ───────────────────────────────────────────────────

--- a/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
@@ -20,6 +20,7 @@ import at.aau.se2.skyjo.model.GameActionMessage
 import at.aau.se2.skyjo.model.GameConfig
 import at.aau.se2.skyjo.model.lobby.LobbyPlayer
 import at.aau.se2.skyjo.persistence.AuthRepository
+import at.aau.se2.skyjo.persistence.GameRepository
 import at.aau.se2.skyjo.persistence.StatsRepository
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -890,7 +891,7 @@ class GameServiceTest {
 
     @Test
     fun `handleRoundFinished accumulates scores into totalScores`() {
-        service.startGame(players, GameConfig(maxRounds = 2))
+        service.startGame(players, GameConfig(maxRounds = 2, targetScore = 1000))
 
         // Build a finished round state with known scores by using engine directly
         val currentState = service.getCurrentState()!!
@@ -933,6 +934,27 @@ class GameServiceTest {
 
         assertTrue(result.gameOver)
         assertEquals(GamePhase.ROUND_FINISHED, result.phase)
+    }
+
+    @Test
+    fun `completed game is not active or rejoinable`() {
+        val dataSource = SingleConnectionDataSource("jdbc:sqlite::memory:", true)
+        val jdbc = JdbcTemplate(dataSource)
+        val repository = GameRepository(jdbc)
+        repository.initSchema()
+        service = GameService(engine, repository)
+        service.startGame(players, GameConfig(maxRounds = 1))
+        val gameState = getInternalGameState(service)
+        val finishedState = engine.finishRound(gameState.copy(finisherPlayerId = gameState.currentPlayerId!!))
+
+        val result = service.handleRoundFinished(finishedState)
+
+        assertTrue(result.gameOver)
+        assertNull(repository.getPlayerGame(player1Id))
+        assertNull(service.getActiveGameId())
+        assertNull(service.reconnectPlayer(player1Id, "Alice", result.gameId!!))
+        assertNull(service.getCurrentState(player1Id))
+        assertNull(GameService(engine, repository).getCurrentState(player1Id))
     }
 
     @Test

--- a/src/test/kotlin/at/aau/se2/skyjo/service/LobbyInviteServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/LobbyInviteServiceTest.kt
@@ -2,6 +2,7 @@ package at.aau.se2.skyjo.service
 
 import at.aau.se2.skyjo.model.auth.AuthUserDto
 import at.aau.se2.skyjo.model.social.LobbyInviteStatus
+import at.aau.se2.skyjo.model.social.RelationshipStatus
 import at.aau.se2.skyjo.persistence.AuthRepository
 import at.aau.se2.skyjo.persistence.FriendRepository
 import at.aau.se2.skyjo.persistence.LobbyInviteRepository
@@ -199,6 +200,29 @@ class LobbyInviteServiceTest {
         }
 
         assertTrue(error.message.orEmpty().contains("not pending"))
+    }
+
+    @Test
+    fun `createInvite rejects user already in the lobby`() {
+        val lobby = lobbyService.createLobby(user("user-a", "Alice"))
+        lobbyService.joinLobby(user("user-b", "Bob"), lobby.joinCode!!)
+
+        val error = assertThrows<IllegalStateException> {
+            service.createInvite(user("user-a", "Alice"), lobby.lobbyId!!, toUserId = "user-b")
+        }
+
+        assertTrue(error.message.orEmpty().contains("already in the lobby"))
+    }
+
+    @Test
+    fun `listInvites returns FRIENDS status on from field because only friends can invite`() {
+        val lobby = lobbyService.createLobby(user("user-a", "Alice"))
+        service.createInvite(user("user-a", "Alice"), lobby.lobbyId!!, toUserId = "user-b")
+
+        val invites = service.listInvites(user("user-b", "Bob"))
+
+        // Alice and Bob are friends — from Bob's view Alice's status is FRIENDS (not the old NONE)
+        assertEquals(RelationshipStatus.FRIENDS, invites.single().from.relationshipStatus)
     }
 
     private fun createUser(userId: String, username: String) {

--- a/src/test/kotlin/at/aau/se2/skyjo/service/LobbyInviteServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/LobbyInviteServiceTest.kt
@@ -74,6 +74,28 @@ class LobbyInviteServiceTest {
     }
 
     @Test
+    fun `createInvite rejects self invites`() {
+        val lobby = lobbyService.createLobby(user("user-a", "Alice"))
+
+        val error = assertThrows<IllegalStateException> {
+            service.createInvite(user("user-a", "Alice"), lobby.lobbyId!!, toUserId = "user-a")
+        }
+
+        assertTrue(error.message.orEmpty().contains("yourself"))
+    }
+
+    @Test
+    fun `createInvite rejects unknown target users`() {
+        val lobby = lobbyService.createLobby(user("user-a", "Alice"))
+
+        val error = assertThrows<IllegalStateException> {
+            service.createInvite(user("user-a", "Alice"), lobby.lobbyId!!, toUserId = "missing")
+        }
+
+        assertTrue(error.message.orEmpty().contains("user not found"))
+    }
+
+    @Test
     fun `createInvite requires inviter to be lobby member`() {
         val lobby = lobbyService.createLobby(user("user-a", "Alice"))
 
@@ -85,6 +107,41 @@ class LobbyInviteServiceTest {
     }
 
     @Test
+    fun `createInvite rejects non-waiting lobbies`() {
+        val lobby = lobbyService.createLobby(user("user-a", "Alice"))
+        lobbyService.joinLobby(user("user-b", "Bob"), lobby.joinCode!!)
+        lobbyService.startGame(userId = "user-a", lobbyId = lobby.lobbyId!!)
+
+        val error = assertThrows<IllegalStateException> {
+            service.createInvite(user("user-a", "Alice"), lobby.lobbyId!!, toUserId = "user-b")
+        }
+
+        assertTrue(error.message.orEmpty().contains("not waiting"))
+    }
+
+    @Test
+    fun `createInvite rejects duplicate pending invites`() {
+        val lobby = lobbyService.createLobby(user("user-a", "Alice"))
+        service.createInvite(user("user-a", "Alice"), lobby.lobbyId!!, toUserId = "user-b")
+
+        val error = assertThrows<IllegalStateException> {
+            service.createInvite(user("user-a", "Alice"), lobby.lobbyId!!, toUserId = "user-b")
+        }
+
+        assertTrue(error.message.orEmpty().contains("already exists"))
+    }
+
+    @Test
+    fun `listInvites returns pending invites for the invited user`() {
+        val lobby = lobbyService.createLobby(user("user-a", "Alice"))
+        service.createInvite(user("user-a", "Alice"), lobby.lobbyId!!, toUserId = "user-b")
+
+        val invites = service.listInvites(user("user-b", "Bob"))
+
+        assertEquals(listOf("ABC123"), invites.map { it.joinCode })
+    }
+
+    @Test
     fun `acceptInvite joins invited user into lobby`() {
         val lobby = lobbyService.createLobby(user("user-a", "Alice"))
         val invite = service.createInvite(user("user-a", "Alice"), lobby.lobbyId!!, toUserId = "user-b")
@@ -93,6 +150,55 @@ class LobbyInviteServiceTest {
 
         assertEquals(LobbyInviteStatus.ACCEPTED, accepted.status)
         assertEquals(listOf("Alice", "Bob"), lobbyService.getLobbyById(lobby.lobbyId!!)?.players?.map { it.nickname })
+    }
+
+    @Test
+    fun `acceptInvite rejects users that are not invited`() {
+        val lobby = lobbyService.createLobby(user("user-a", "Alice"))
+        val invite = service.createInvite(user("user-a", "Alice"), lobby.lobbyId!!, toUserId = "user-b")
+
+        assertThrows<UnauthorizedException> {
+            service.acceptInvite(user("user-c", "Cara"), invite.inviteId)
+        }
+    }
+
+    @Test
+    fun `acceptInvite rejects invites for lobbies that are no longer waiting`() {
+        val lobby = lobbyService.createLobby(user("user-a", "Alice"))
+        val lobbyId = lobby.lobbyId!!
+        val invite = service.createInvite(user("user-a", "Alice"), lobbyId, toUserId = "user-b")
+        lobbyService.joinLobby(user("user-c", "Cara"), lobby.joinCode!!)
+        lobbyService.startGame(userId = "user-a", lobbyId = lobbyId)
+
+        val error = assertThrows<IllegalStateException> {
+            service.acceptInvite(user("user-b", "Bob"), invite.inviteId)
+        }
+
+        assertTrue(error.message.orEmpty().contains("not waiting"))
+    }
+
+    @Test
+    fun `declineInvite marks invite declined and hides it from pending invites`() {
+        val lobby = lobbyService.createLobby(user("user-a", "Alice"))
+        val invite = service.createInvite(user("user-a", "Alice"), lobby.lobbyId!!, toUserId = "user-b")
+
+        val declined = service.declineInvite(user("user-b", "Bob"), invite.inviteId)
+
+        assertEquals(LobbyInviteStatus.DECLINED, declined.status)
+        assertTrue(service.listInvites(user("user-b", "Bob")).isEmpty())
+    }
+
+    @Test
+    fun `declineInvite rejects invites that are no longer pending`() {
+        val lobby = lobbyService.createLobby(user("user-a", "Alice"))
+        val invite = service.createInvite(user("user-a", "Alice"), lobby.lobbyId!!, toUserId = "user-b")
+        service.declineInvite(user("user-b", "Bob"), invite.inviteId)
+
+        val error = assertThrows<IllegalStateException> {
+            service.declineInvite(user("user-b", "Bob"), invite.inviteId)
+        }
+
+        assertTrue(error.message.orEmpty().contains("not pending"))
     }
 
     private fun createUser(userId: String, username: String) {

--- a/src/test/kotlin/at/aau/se2/skyjo/service/LobbyInviteServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/LobbyInviteServiceTest.kt
@@ -1,0 +1,103 @@
+package at.aau.se2.skyjo.service
+
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.social.LobbyInviteStatus
+import at.aau.se2.skyjo.persistence.AuthRepository
+import at.aau.se2.skyjo.persistence.FriendRepository
+import at.aau.se2.skyjo.persistence.LobbyInviteRepository
+import at.aau.se2.skyjo.persistence.LobbyRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
+
+class LobbyInviteServiceTest {
+
+    private lateinit var authRepository: AuthRepository
+    private lateinit var friendRepository: FriendRepository
+    private lateinit var lobbyRepository: LobbyRepository
+    private lateinit var inviteRepository: LobbyInviteRepository
+    private lateinit var lobbyService: LobbyService
+    private lateinit var service: LobbyInviteService
+
+    @BeforeEach
+    fun setUp() {
+        val dataSource = SingleConnectionDataSource("jdbc:sqlite::memory:", true)
+        val jdbc = JdbcTemplate(dataSource)
+        authRepository = AuthRepository(jdbc)
+        friendRepository = FriendRepository(jdbc)
+        lobbyRepository = LobbyRepository(jdbc)
+        inviteRepository = LobbyInviteRepository(jdbc)
+        authRepository.initSchema()
+        friendRepository.initSchema()
+        lobbyRepository.initSchema()
+        inviteRepository.initSchema()
+        createUser("user-a", "Alice")
+        createUser("user-b", "Bob")
+        createUser("user-c", "Cara")
+        friendRepository.createFriendship("user-a", "user-b", now = 1_000L)
+        friendRepository.createFriendship("user-b", "user-a", now = 1_000L)
+        lobbyService = LobbyService(
+            repository = lobbyRepository,
+            joinCodeGenerator = object : JoinCodeGenerator {
+                override fun generateCode(): String = "ABC123"
+            },
+            idGenerator = object : LobbyIdGenerator {
+                override fun generateId(): String = "lobby-1"
+            },
+            nowProvider = { 1_000L },
+        )
+        service = LobbyInviteService(
+            repository = inviteRepository,
+            authRepository = authRepository,
+            friendRepository = friendRepository,
+            lobbyService = lobbyService,
+            inviteIdGenerator = object : LobbyInviteIdGenerator {
+                override fun generateId(): String = "invite-1"
+            },
+            nowProvider = { 2_000L },
+        )
+    }
+
+    @Test
+    fun `createInvite rejects non-friends`() {
+        val lobby = lobbyService.createLobby(user("user-a", "Alice"))
+
+        val error = assertThrows<IllegalStateException> {
+            service.createInvite(user("user-a", "Alice"), lobby.lobbyId!!, toUserId = "user-c")
+        }
+
+        assertTrue(error.message.orEmpty().contains("friends"))
+    }
+
+    @Test
+    fun `createInvite requires inviter to be lobby member`() {
+        val lobby = lobbyService.createLobby(user("user-a", "Alice"))
+
+        val error = assertThrows<IllegalStateException> {
+            service.createInvite(user("user-b", "Bob"), lobby.lobbyId!!, toUserId = "user-a")
+        }
+
+        assertTrue(error.message.orEmpty().contains("lobby member"))
+    }
+
+    @Test
+    fun `acceptInvite joins invited user into lobby`() {
+        val lobby = lobbyService.createLobby(user("user-a", "Alice"))
+        val invite = service.createInvite(user("user-a", "Alice"), lobby.lobbyId!!, toUserId = "user-b")
+
+        val accepted = service.acceptInvite(user("user-b", "Bob"), invite.inviteId)
+
+        assertEquals(LobbyInviteStatus.ACCEPTED, accepted.status)
+        assertEquals(listOf("Alice", "Bob"), lobbyService.getLobbyById(lobby.lobbyId!!)?.players?.map { it.nickname })
+    }
+
+    private fun createUser(userId: String, username: String) {
+        authRepository.createUser(userId, username, "hash-$userId", now = 1L)
+    }
+
+    private fun user(userId: String, username: String) = AuthUserDto(userId = userId, username = username)
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/LobbyServiceTest.kt
@@ -1,5 +1,6 @@
 package at.aau.se2.skyjo.service
 
+import at.aau.se2.skyjo.model.auth.AuthUserDto
 import at.aau.se2.skyjo.model.lobby.LobbyStatus
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -14,6 +15,8 @@ class LobbyServiceTest {
     fun setUp() {
         service = LobbyService()
     }
+
+    private fun authUser(userId: String, username: String) = AuthUserDto(userId = userId, username = username)
 
     @Test
     fun `first player to join becomes host`() {
@@ -180,5 +183,32 @@ class LobbyServiceTest {
 
         assertEquals(LobbyStatus.IN_GAME, state.status)
         assertEquals(1, state.players.size)
+    }
+
+    @Test
+    fun `createLobby blocks user who already has a WAITING lobby`() {
+        service.createLobby(authUser("user-a", "Alice"))
+
+        val ex = assertThrows<IllegalStateException> { service.createLobby(authUser("user-a", "Alice")) }
+        assertTrue(ex.message!!.contains("already in a lobby"))
+    }
+
+    @Test
+    fun `createLobby blocks user who is in an IN_GAME lobby`() {
+        val lobby = service.createLobby(authUser("user-a", "Alice"))
+        service.joinLobby(authUser("user-b", "Bob"), lobby.joinCode!!)
+        service.startGame(userId = "user-a", lobbyId = lobby.lobbyId!!)
+
+        val ex = assertThrows<IllegalStateException> { service.createLobby(authUser("user-a", "Alice")) }
+        assertTrue(ex.message!!.contains("already in a lobby"))
+    }
+
+    @Test
+    fun `createLobby allows user whose previous lobby is CLOSED`() {
+        val lobby = service.createLobby(authUser("user-a", "Alice"))
+        service.leaveLobby("user-a", lobby.lobbyId!!)
+
+        val newLobby = service.createLobby(authUser("user-a", "Alice"))
+        assertNotNull(newLobby.lobbyId)
     }
 }

--- a/src/test/kotlin/at/aau/se2/skyjo/service/MultiLobbyServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/MultiLobbyServiceTest.kt
@@ -1,0 +1,100 @@
+package at.aau.se2.skyjo.service
+
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.lobby.LobbyStatus
+import at.aau.se2.skyjo.persistence.LobbyRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
+
+class MultiLobbyServiceTest {
+
+    private lateinit var service: LobbyService
+    private val codes = ArrayDeque(listOf("AAAAAA", "BBBBBB", "CCCCCC"))
+
+    @BeforeEach
+    fun setUp() {
+        val dataSource = SingleConnectionDataSource("jdbc:sqlite::memory:", true)
+        val repo = LobbyRepository(JdbcTemplate(dataSource))
+        repo.initSchema()
+        service = LobbyService(
+            repository = repo,
+            joinCodeGenerator = object : JoinCodeGenerator {
+                override fun generateCode(): String = codes.removeFirst()
+            },
+            idGenerator = object : LobbyIdGenerator {
+                private var next = 0
+                override fun generateId(): String {
+                    next += 1
+                    return "lobby-$next"
+                }
+            },
+            nowProvider = { 1_000L },
+        )
+    }
+
+    @Test
+    fun `users can create separate lobbies with distinct join codes`() {
+        val first = service.createLobby(user("user-1", "Alice"))
+        val second = service.createLobby(user("user-2", "Bob"))
+
+        assertNotEquals(first.lobbyId, second.lobbyId)
+        assertEquals("AAAAAA", first.joinCode)
+        assertEquals("BBBBBB", second.joinCode)
+        assertEquals("Alice", first.players.single().nickname)
+        assertEquals("Bob", second.players.single().nickname)
+    }
+
+    @Test
+    fun `joinLobby joins only the lobby matching the join code`() {
+        val first = service.createLobby(user("user-1", "Alice"))
+        val second = service.createLobby(user("user-2", "Bob"))
+
+        val joined = service.joinLobby(user("user-3", "Cara"), second.joinCode!!)
+
+        assertEquals(first.lobbyId, service.getLobbyById(first.lobbyId!!)?.lobbyId)
+        assertEquals(listOf("Bob", "Cara"), joined.players.map { it.nickname })
+    }
+
+    @Test
+    fun `user cannot join two waiting lobbies`() {
+        service.createLobby(user("user-1", "Alice"))
+        service.createLobby(user("user-2", "Bob"))
+
+        val error = assertThrows<IllegalStateException> {
+            service.joinLobby(user("user-1", "Alice"), "BBBBBB")
+        }
+
+        assertTrue(error.message.orEmpty().contains("already in a lobby"))
+    }
+
+    @Test
+    fun `host leaving reassigns host in that lobby`() {
+        val lobby = service.createLobby(user("user-1", "Alice"))
+        service.joinLobby(user("user-2", "Bob"), lobby.joinCode!!)
+
+        val updated = service.leaveLobby(userId = "user-1", lobbyId = lobby.lobbyId!!)
+
+        assertEquals(listOf("Bob"), updated.players.map { it.nickname })
+        assertTrue(updated.players.single().isHost)
+    }
+
+    @Test
+    fun `startGame marks only selected lobby in game`() {
+        val first = service.createLobby(user("user-1", "Alice"))
+        service.joinLobby(user("user-2", "Bob"), first.joinCode!!)
+        val second = service.createLobby(user("user-3", "Cara"))
+
+        val started = service.startGame(userId = "user-1", lobbyId = first.lobbyId!!)
+
+        assertEquals(LobbyStatus.IN_GAME, started.status)
+        assertEquals(LobbyStatus.WAITING, service.getLobbyById(second.lobbyId!!)?.status)
+    }
+
+    private fun user(id: String, username: String) = AuthUserDto(userId = id, username = username)
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/service/MultiLobbyServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/MultiLobbyServiceTest.kt
@@ -74,6 +74,26 @@ class MultiLobbyServiceTest {
     }
 
     @Test
+    fun `createLobby rejects user already in waiting lobby`() {
+        service.createLobby(user("user-1", "Alice"))
+
+        val error = assertThrows<IllegalStateException> {
+            service.createLobby(user("user-1", "Alice"))
+        }
+
+        assertTrue(error.message.orEmpty().contains("already in a lobby"))
+    }
+
+    @Test
+    fun `joinLobby is idempotent for users already in that lobby`() {
+        val lobby = service.createLobby(user("user-1", "Alice"))
+
+        val joined = service.joinLobby(user("user-1", "Alice"), lobby.joinCode!!)
+
+        assertEquals(listOf("Alice"), joined.players.map { it.nickname })
+    }
+
+    @Test
     fun `host leaving reassigns host in that lobby`() {
         val lobby = service.createLobby(user("user-1", "Alice"))
         service.joinLobby(user("user-2", "Bob"), lobby.joinCode!!)
@@ -82,6 +102,26 @@ class MultiLobbyServiceTest {
 
         assertEquals(listOf("Bob"), updated.players.map { it.nickname })
         assertTrue(updated.players.single().isHost)
+    }
+
+    @Test
+    fun `last player leaving closes the lobby`() {
+        val lobby = service.createLobby(user("user-1", "Alice"))
+
+        val updated = service.leaveLobby(userId = "user-1", lobbyId = lobby.lobbyId!!)
+
+        assertEquals(LobbyStatus.CLOSED, updated.status)
+        assertTrue(updated.players.isEmpty())
+    }
+
+    @Test
+    fun `non-member leaving keeps lobby members unchanged`() {
+        val lobby = service.createLobby(user("user-1", "Alice"))
+        service.joinLobby(user("user-2", "Bob"), lobby.joinCode!!)
+
+        val updated = service.leaveLobby(userId = "missing", lobbyId = lobby.lobbyId!!)
+
+        assertEquals(listOf("Alice", "Bob"), updated.players.map { it.nickname })
     }
 
     @Test
@@ -94,6 +134,46 @@ class MultiLobbyServiceTest {
 
         assertEquals(LobbyStatus.IN_GAME, started.status)
         assertEquals(LobbyStatus.WAITING, service.getLobbyById(second.lobbyId!!)?.status)
+    }
+
+    @Test
+    fun `startGame rejects non-host users`() {
+        val lobby = service.createLobby(user("user-1", "Alice"))
+        service.joinLobby(user("user-2", "Bob"), lobby.joinCode!!)
+
+        val error = assertThrows<IllegalStateException> {
+            service.startGame(userId = "user-2", lobbyId = lobby.lobbyId!!)
+        }
+
+        assertTrue(error.message.orEmpty().contains("host"))
+    }
+
+    @Test
+    fun `startGame rejects lobbies with one player`() {
+        val lobby = service.createLobby(user("user-1", "Alice"))
+
+        val error = assertThrows<IllegalStateException> {
+            service.startGame(userId = "user-1", lobbyId = lobby.lobbyId!!)
+        }
+
+        assertTrue(error.message.orEmpty().contains("2 players"))
+    }
+
+    @Test
+    fun `joinLobby rejects full lobbies`() {
+        val lobby = service.createLobby(user("user-1", "Alice"))
+        val joinCode = lobby.joinCode!!
+        service.joinLobby(user("user-2", "Bob"), joinCode)
+        service.joinLobby(user("user-3", "Cara"), joinCode)
+        service.joinLobby(user("user-4", "Dan"), joinCode)
+        service.joinLobby(user("user-5", "Eve"), joinCode)
+        service.joinLobby(user("user-6", "Finn"), joinCode)
+
+        val error = assertThrows<IllegalStateException> {
+            service.joinLobby(user("user-7", "Gina"), joinCode)
+        }
+
+        assertTrue(error.message.orEmpty().contains("full"))
     }
 
     private fun user(id: String, username: String) = AuthUserDto(userId = id, username = username)

--- a/src/test/kotlin/at/aau/se2/skyjo/service/StatsServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/StatsServiceTest.kt
@@ -1,0 +1,49 @@
+package at.aau.se2.skyjo.service
+
+import at.aau.se2.skyjo.persistence.AuthRepository
+import at.aau.se2.skyjo.persistence.StatsRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.datasource.SingleConnectionDataSource
+
+class StatsServiceTest {
+
+    private lateinit var authRepository: AuthRepository
+    private lateinit var repository: StatsRepository
+    private lateinit var service: StatsService
+
+    @BeforeEach
+    fun setUp() {
+        val dataSource = SingleConnectionDataSource("jdbc:sqlite::memory:", true)
+        val jdbc = JdbcTemplate(dataSource)
+        authRepository = AuthRepository(jdbc)
+        repository = StatsRepository(jdbc)
+        authRepository.initSchema()
+        repository.initSchema()
+        createUser("user-a", "Alice")
+        createUser("user-b", "Bob")
+        service = StatsService(repository, authRepository, nowProvider = { 1_000L })
+    }
+
+    @Test
+    fun `recordGameResult marks lowest score as winner`() {
+        service.recordGameResult("game-1", mapOf("user-a" to 42, "user-b" to 10))
+
+        assertEquals(0, service.getStats("user-a").wins)
+        assertEquals(1, service.getStats("user-b").wins)
+    }
+
+    @Test
+    fun `getStats returns zero state for user without games`() {
+        val stats = service.getStats("user-a")
+
+        assertEquals(0, stats.gamesPlayed)
+        assertEquals(0.0, stats.averageScore)
+    }
+
+    private fun createUser(userId: String, username: String) {
+        authRepository.createUser(userId, username, "hash-$userId", now = 1L)
+    }
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/service/StatsServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/StatsServiceTest.kt
@@ -5,6 +5,7 @@ import at.aau.se2.skyjo.persistence.StatsRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.datasource.SingleConnectionDataSource
 
@@ -36,11 +37,44 @@ class StatsServiceTest {
     }
 
     @Test
+    fun `recordGameResult treats tied lowest scores as multiple winners`() {
+        service.recordGameResult("game-1", mapOf("user-a" to 10, "user-b" to 10))
+
+        assertEquals(1, service.getStats("user-a").wins)
+        assertEquals(1, service.getStats("user-b").wins)
+    }
+
+    @Test
+    fun `recordGameResult ignores empty score maps`() {
+        service.recordGameResult("game-empty", emptyMap())
+
+        assertEquals(0, service.getStats("user-a").gamesPlayed)
+    }
+
+    @Test
     fun `getStats returns zero state for user without games`() {
         val stats = service.getStats("user-a")
 
         assertEquals(0, stats.gamesPlayed)
         assertEquals(0.0, stats.averageScore)
+    }
+
+    @Test
+    fun `getStats rejects unknown users`() {
+        assertThrows<UnauthorizedException> {
+            service.getStats("missing")
+        }
+    }
+
+    @Test
+    fun `leaderboard ranks players and clamps invalid limits`() {
+        service.recordGameResult("game-1", mapOf("user-a" to 7, "user-b" to 15))
+
+        val leaderboard = service.leaderboard(0)
+
+        assertEquals(1, leaderboard.size)
+        assertEquals("Alice", leaderboard.single().username)
+        assertEquals(1, leaderboard.single().rank)
     }
 
     private fun createUser(userId: String, username: String) {


### PR DESCRIPTION
## Summary
- Add secure username/password auth with BCrypt, hashed sessions, and short-lived WebSocket tickets.
- Replace the single global lobby/game path with join-code lobbies, multiple active games, friend requests, lobby invites, and leaderboard stats.
- Persist auth, lobbies, social data, invites, game sessions, and stats in SQLite.

## Test Plan
- `./gradlew test build`
- Runtime backend request suite against local `SERVER_PORT=18080` and temporary SQLite DB:
  - health endpoint
  - register/login/me/logout/ws-ticket auth paths
  - duplicate username, invalid input, wrong password, unauthorized auth paths
  - multiple waiting lobbies, case-insensitive join code, invalid join code, second-lobby rejection
  - friend request self/duplicate/unauthorized-accept/recipient-accept paths
  - lobby invite non-friend rejection, list, accept once, current lobby after accept
  - stats and leaderboard response shape