### PR TITLE
Fix lobby cleanup after game finish

### DIFF
--- a/src/main/kotlin/at/aau/se2/skyjo/config/AppConfig.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/config/AppConfig.kt
@@ -2,6 +2,7 @@ package at.aau.se2.skyjo.config
 
 import at.aau.se2.skyjo.game.service.SkyjoEngine
 import at.aau.se2.skyjo.persistence.LobbyRepository
+import at.aau.se2.skyjo.service.AuthService
 import at.aau.se2.skyjo.service.LobbyService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -12,5 +13,6 @@ class AppConfig {
     fun skyjoEngine(): SkyjoEngine = SkyjoEngine()
 
     @Bean
-    fun lobbyService(lobbyRepository: LobbyRepository): LobbyService = LobbyService(repository = lobbyRepository)
+    fun lobbyService(lobbyRepository: LobbyRepository, authService: AuthService): LobbyService =
+        LobbyService(repository = lobbyRepository, authService = authService)
 }

--- a/src/main/kotlin/at/aau/se2/skyjo/persistence/AuthRepository.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/persistence/AuthRepository.kt
@@ -254,6 +254,19 @@ class AuthRepository(private val jdbc: JdbcTemplate) {
         )
     }
 
+    fun clearCurrentLobby(lobbyId: String, now: Long) {
+        jdbc.update(
+            """
+            UPDATE user_presence
+            SET current_lobby_id = NULL,
+                updated_at = ?
+            WHERE current_lobby_id = ?
+            """.trimIndent(),
+            now,
+            lobbyId,
+        )
+    }
+
     fun getPresence(userId: String): UserPresenceRecord? =
         jdbc.query(
             """

--- a/src/main/kotlin/at/aau/se2/skyjo/service/AuthService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/AuthService.kt
@@ -144,6 +144,10 @@ class AuthService @Autowired constructor(
         )
     }
 
+    fun clearCurrentLobby(lobbyId: String) {
+        repository.clearCurrentLobby(lobbyId, nowProvider())
+    }
+
     private fun createAuthResponse(userId: String, username: String, now: Long): AuthResponse {
         val token = tokenGenerator.generateToken()
         repository.createSession(

--- a/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
@@ -43,6 +43,7 @@ class GameService @Autowired constructor(
     private val engine: SkyjoEngine,
     private val gameRepository: GameRepository?,
     private val statsService: StatsService?,
+    private val lobbyService: LobbyService? = null,
 ) {
 
     private data class ManagedGame(
@@ -72,7 +73,7 @@ class GameService @Autowired constructor(
     private val sessionAliases: MutableMap<String, String> = mutableMapOf()
     private val disconnectedNicknames: MutableSet<String> = mutableSetOf()
 
-    constructor(engine: SkyjoEngine, gameRepository: GameRepository?) : this(engine, gameRepository, null)
+    constructor(engine: SkyjoEngine, gameRepository: GameRepository?) : this(engine, gameRepository, null, null)
 
     init {
         gameRepository?.loadActiveGames()?.forEach { persisted ->
@@ -357,6 +358,7 @@ class GameService @Autowired constructor(
             game.completed = true
             gameRepository?.saveGame(game.gameId, game.lobbyId, finishedState, completed = true)
             gameRepository?.deletePlayerSessionsForGame(game.gameId)
+            game.lobbyId?.let { lobbyService?.closeLobby(it) }
             removePlayerIndexes(game)
             recordFinalStatsOnce(game)
             syncLegacyIfCurrent(game)

--- a/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
@@ -190,6 +190,9 @@ class LobbyService(
 
     fun startGame(userId: String, lobbyId: String): LobbyState = lock.withLock {
         val lobby = getLobbyById(lobbyId) ?: error("lobby not found")
+        if (lobby.status != LobbyStatus.WAITING) {
+            error("cannot start game: lobby is not waiting")
+        }
         val caller = lobby.players.find { it.userId == userId } ?: error("player not in lobby")
         if (!caller.isHost) {
             error("only the host can start the game")
@@ -202,6 +205,13 @@ class LobbyService(
             ?: run { inMemoryLobbies[lobbyId] = lobby.copy(status = LobbyStatus.IN_GAME) }
 
         getLobbyById(lobbyId) ?: error("started lobby is not available")
+    }
+
+    fun closeLobby(lobbyId: String): LobbyState? = lock.withLock {
+        val lobby = getLobbyById(lobbyId) ?: return@withLock null
+        repository?.updateLobbyStatus(lobbyId, LobbyStatus.CLOSED, nowProvider())
+            ?: run { inMemoryLobbies[lobbyId] = lobby.copy(status = LobbyStatus.CLOSED) }
+        getLobbyById(lobbyId) ?: lobby.copy(status = LobbyStatus.CLOSED)
     }
 
     fun getLobbyById(lobbyId: String): LobbyState? = lock.withLock {

--- a/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
@@ -210,8 +210,11 @@ class LobbyService(
     fun closeLobby(lobbyId: String): LobbyState? = lock.withLock {
         val lobby = getLobbyById(lobbyId) ?: return@withLock null
         repository?.updateLobbyStatus(lobbyId, LobbyStatus.CLOSED, nowProvider())
-            ?: run { inMemoryLobbies[lobbyId] = lobby.copy(status = LobbyStatus.CLOSED) }
-        getLobbyById(lobbyId) ?: lobby.copy(status = LobbyStatus.CLOSED)
+            ?: run {
+                lobby.players.map { it.userId }.forEach(inMemoryUserLobbyIds::remove)
+                inMemoryLobbies[lobbyId] = lobby.copy(status = LobbyStatus.CLOSED)
+            }
+        getLobbyById(lobbyId)
     }
 
     fun getLobbyById(lobbyId: String): LobbyState? = lock.withLock {

--- a/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
@@ -36,6 +36,7 @@ class RandomLobbyIdGenerator : LobbyIdGenerator {
 
 class LobbyService(
     private val repository: LobbyRepository? = null,
+    private val authService: AuthService? = null,
     private val joinCodeGenerator: JoinCodeGenerator = RandomJoinCodeGenerator(),
     private val idGenerator: LobbyIdGenerator = RandomLobbyIdGenerator(),
     private val nowProvider: () -> Long = { System.currentTimeMillis() },
@@ -76,6 +77,9 @@ class LobbyService(
     }
 
     fun startGame(sessionId: String): LobbyState = lock.withLock {
+        if (state.status != LobbyStatus.WAITING) {
+            error("cannot start game: lobby is not waiting")
+        }
         val caller = state.players.find { it.sessionId == sessionId }
             ?: error("player not in lobby")
         if (!caller.isHost) {
@@ -214,6 +218,7 @@ class LobbyService(
                 lobby.players.map { it.userId }.forEach(inMemoryUserLobbyIds::remove)
                 inMemoryLobbies[lobbyId] = lobby.copy(status = LobbyStatus.CLOSED)
             }
+        authService?.clearCurrentLobby(lobbyId)
         getLobbyById(lobbyId)
     }
 

--- a/src/test/kotlin/at/aau/se2/skyjo/persistence/AuthRepositoryTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/persistence/AuthRepositoryTest.kt
@@ -122,4 +122,22 @@ class AuthRepositoryTest {
         assertFalse(offline?.connected == true)
         assertNull(offline?.currentLobbyId)
     }
+
+    @Test
+    fun `current lobby can be cleared without changing presence state`() {
+        repo.createUser("user-1", "Alice", "hash", now = 1_000L)
+        repo.createUser("user-2", "Bob", "hash", now = 1_000L)
+        repo.setPresence(userId = "user-1", connected = true, currentLobbyId = "lobby-1", now = 2_000L)
+        repo.setPresence(userId = "user-2", connected = true, currentLobbyId = "lobby-2", now = 2_000L)
+
+        repo.clearCurrentLobby("lobby-1", now = 3_000L)
+
+        val cleared = repo.getPresence("user-1")
+        val unchanged = repo.getPresence("user-2")
+        assertTrue(cleared?.connected == true)
+        assertNull(cleared?.currentLobbyId)
+        assertEquals(3_000L, cleared?.updatedAt)
+        assertEquals("lobby-2", unchanged?.currentLobbyId)
+        assertEquals(2_000L, unchanged?.updatedAt)
+    }
 }

--- a/src/test/kotlin/at/aau/se2/skyjo/service/GameLobbyLifecycleIntegrationTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/GameLobbyLifecycleIntegrationTest.kt
@@ -1,0 +1,53 @@
+package at.aau.se2.skyjo.service
+
+import at.aau.se2.skyjo.game.model.GameState
+import at.aau.se2.skyjo.game.service.SkyjoEngine
+import at.aau.se2.skyjo.model.GameConfig
+import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.lobby.LobbyStatus
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class GameLobbyLifecycleIntegrationTest {
+
+    @Autowired
+    private lateinit var lobbyService: LobbyService
+
+    @Autowired
+    private lateinit var gameService: GameService
+
+    @Autowired
+    private lateinit var engine: SkyjoEngine
+
+    @Test
+    fun `game over closes source lobby so players are not returned to it`() {
+        val lobby = lobbyService.createLobby(user("lifecycle-user-a", "Alice"))
+        val lobbyId = lobby.lobbyId!!
+        lobbyService.joinLobby(user("lifecycle-user-b", "Bob"), lobby.joinCode!!)
+        val inGameLobby = lobbyService.startGame(userId = "lifecycle-user-a", lobbyId = lobbyId)
+        gameService.startGame(lobbyId, inGameLobby.players, GameConfig(maxRounds = 1))
+        val gameState = getInternalGameState(gameService)
+        val finishedState = engine.finishRound(gameState.copy(finisherPlayerId = gameState.currentPlayerId!!))
+
+        val result = gameService.handleRoundFinished(finishedState)
+
+        assertTrue(result.gameOver)
+        assertNull(lobbyService.getCurrentLobbyForUser("lifecycle-user-a"))
+        assertEquals(LobbyStatus.CLOSED, lobbyService.getLobbyById(lobbyId)?.status)
+    }
+
+    private fun user(id: String, username: String) = AuthUserDto(userId = id, username = username)
+
+    private fun getInternalGameState(service: GameService): GameState {
+        val field = GameService::class.java.getDeclaredField("gameState")
+        field.isAccessible = true
+        return field.get(service) as GameState
+    }
+}

--- a/src/test/kotlin/at/aau/se2/skyjo/service/GameLobbyLifecycleIntegrationTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/GameLobbyLifecycleIntegrationTest.kt
@@ -1,10 +1,13 @@
 package at.aau.se2.skyjo.service
 
-import at.aau.se2.skyjo.game.model.GameState
-import at.aau.se2.skyjo.game.service.SkyjoEngine
+import at.aau.se2.skyjo.game.model.DrawSource
+import at.aau.se2.skyjo.model.ActionType
+import at.aau.se2.skyjo.model.GameActionMessage
 import at.aau.se2.skyjo.model.GameConfig
-import at.aau.se2.skyjo.model.auth.AuthUserDto
+import at.aau.se2.skyjo.model.GameUpdateMessage
+import at.aau.se2.skyjo.model.SlotType
 import at.aau.se2.skyjo.model.lobby.LobbyStatus
+import at.aau.se2.skyjo.persistence.AuthRepository
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -24,30 +27,74 @@ class GameLobbyLifecycleIntegrationTest {
     private lateinit var gameService: GameService
 
     @Autowired
-    private lateinit var engine: SkyjoEngine
+    private lateinit var authService: AuthService
+
+    @Autowired
+    private lateinit var authRepository: AuthRepository
 
     @Test
     fun `game over closes source lobby so players are not returned to it`() {
-        val lobby = lobbyService.createLobby(user("lifecycle-user-a", "Alice"))
+        val alice = authService.register("LifecycleAlice", "password-a").user
+        val bob = authService.register("LifecycleBob", "password-b").user
+        val lobby = lobbyService.createLobby(alice)
         val lobbyId = lobby.lobbyId!!
-        lobbyService.joinLobby(user("lifecycle-user-b", "Bob"), lobby.joinCode!!)
-        val inGameLobby = lobbyService.startGame(userId = "lifecycle-user-a", lobbyId = lobbyId)
-        gameService.startGame(lobbyId, inGameLobby.players, GameConfig(maxRounds = 1))
-        val gameState = getInternalGameState(gameService)
-        val finishedState = engine.finishRound(gameState.copy(finisherPlayerId = gameState.currentPlayerId!!))
+        authService.markUserConnected(alice.userId, lobbyId)
+        lobbyService.joinLobby(bob, lobby.joinCode!!)
+        authService.markUserConnected(bob.userId, lobbyId)
+        val inGameLobby = lobbyService.startGame(userId = alice.userId, lobbyId = lobbyId)
 
-        val result = gameService.handleRoundFinished(finishedState)
+        val result = playUntilGameOver(
+            gameService.startGame(lobbyId, inGameLobby.players, GameConfig(maxRounds = 1))
+        )
 
         assertTrue(result.gameOver)
-        assertNull(lobbyService.getCurrentLobbyForUser("lifecycle-user-a"))
+        assertNull(lobbyService.getCurrentLobbyForUser(alice.userId))
         assertEquals(LobbyStatus.CLOSED, lobbyService.getLobbyById(lobbyId)?.status)
+        assertNull(authRepository.getPresence(alice.userId)?.currentLobbyId)
+        assertNull(authRepository.getPresence(bob.userId)?.currentLobbyId)
+        assertTrue(authRepository.getPresence(alice.userId)?.connected == true)
+        assertTrue(authRepository.getPresence(bob.userId)?.connected == true)
     }
 
-    private fun user(id: String, username: String) = AuthUserDto(userId = id, username = username)
+    private fun playUntilGameOver(initialUpdate: GameUpdateMessage): GameUpdateMessage {
+        var update = initialUpdate
+        var turnCount = 0
+        while (!update.gameOver && turnCount < MAX_TURNS_TO_FINISH_ROUND) {
+            val currentPlayerId = requireNotNull(update.currentPlayerId) { "current player is missing" }
+            update = gameService.processAction(
+                currentPlayerId,
+                GameActionMessage(ActionType.DRAW, source = DrawSource.DECK),
+            )
+            val position = firstFaceDownPosition(update, currentPlayerId)
+            update = if (position != null) {
+                gameService.processAction(
+                    currentPlayerId,
+                    GameActionMessage(ActionType.DISCARD_AND_REVEAL, row = position.first, col = position.second),
+                )
+            } else {
+                gameService.processAction(
+                    currentPlayerId,
+                    GameActionMessage(ActionType.REPLACE, row = 0, col = 0),
+                )
+            }
+            turnCount += 1
+        }
+        return update
+    }
 
-    private fun getInternalGameState(service: GameService): GameState {
-        val field = GameService::class.java.getDeclaredField("gameState")
-        field.isAccessible = true
-        return field.get(service) as GameState
+    private fun firstFaceDownPosition(update: GameUpdateMessage, playerId: String): Pair<Int, Int>? {
+        val board = update.players.first { it.playerId == playerId }.board
+        board.forEachIndexed { rowIndex, row ->
+            row.forEachIndexed { colIndex, slot ->
+                if (slot.type == SlotType.OCCUPIED && slot.faceUp == false) {
+                    return rowIndex to colIndex
+                }
+            }
+        }
+        return null
+    }
+
+    private companion object {
+        const val MAX_TURNS_TO_FINISH_ROUND = 50
     }
 }

--- a/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
@@ -1005,6 +1005,20 @@ class GameServiceTest {
     }
 
     @Test
+    fun `completed lobby game works when no lobby service is configured`() {
+        service = GameService(engine, null)
+        service.startGame("lobby-1", players, GameConfig(maxRounds = 1))
+        val gameState = getInternalGameState(service)
+        val finishedState = engine.finishRound(gameState.copy(finisherPlayerId = gameState.currentPlayerId!!))
+
+        val result = service.handleRoundFinished(finishedState)
+
+        assertTrue(result.gameOver)
+        assertEquals("lobby-1", result.lobbyId)
+        assertNull(service.getCurrentState(player1Id))
+    }
+
+    @Test
     fun `handleRoundFinished sets gameOver when player reaches targetScore`() {
         service.startGame(players, GameConfig(maxRounds = 10, targetScore = 0))
         val gameState = getInternalGameState(service)

--- a/src/test/kotlin/at/aau/se2/skyjo/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/LobbyServiceTest.kt
@@ -211,4 +211,24 @@ class LobbyServiceTest {
         val newLobby = service.createLobby(authUser("user-a", "Alice"))
         assertNotNull(newLobby.lobbyId)
     }
+
+    @Test
+    fun `closeLobby clears in-memory current lobby mappings`() {
+        val oldLobby = service.createLobby(authUser("user-a", "Alice"))
+        val oldLobbyId = oldLobby.lobbyId!!
+        service.joinLobby(authUser("user-b", "Bob"), oldLobby.joinCode!!)
+        service.closeLobby(oldLobbyId)
+        val newLobby = service.createLobby(authUser("user-c", "Cara"))
+
+        val joined = service.joinLobby(authUser("user-a", "Alice"), newLobby.joinCode!!)
+
+        assertEquals(LobbyStatus.CLOSED, service.getLobbyById(oldLobbyId)?.status)
+        assertNull(service.getCurrentLobbyForUser("user-b"))
+        assertEquals(newLobby.lobbyId, joined.lobbyId)
+    }
+
+    @Test
+    fun `closeLobby returns null for unknown lobby`() {
+        assertNull(service.closeLobby("missing-lobby"))
+    }
 }

--- a/src/test/kotlin/at/aau/se2/skyjo/service/LobbyServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/LobbyServiceTest.kt
@@ -114,6 +114,17 @@ class LobbyServiceTest {
     }
 
     @Test
+    fun `starting legacy lobby twice throws error`() {
+        service.join("s1", "Alice")
+        service.join("s2", "Bob")
+        service.startGame("s1")
+
+        val ex = assertThrows<IllegalStateException> { service.startGame("s1") }
+
+        assertTrue(ex.message!!.contains("not waiting"))
+    }
+
+    @Test
     fun `non-lobby player cannot start game`() {
         service.join("s1", "Alice")
         service.join("s2", "Bob")

--- a/src/test/kotlin/at/aau/se2/skyjo/service/MultiLobbyServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/MultiLobbyServiceTest.kt
@@ -137,6 +137,20 @@ class MultiLobbyServiceTest {
     }
 
     @Test
+    fun `startGame rejects lobbies that are already in game`() {
+        val lobby = service.createLobby(user("user-1", "Alice"))
+        val lobbyId = lobby.lobbyId!!
+        service.joinLobby(user("user-2", "Bob"), lobby.joinCode!!)
+        service.startGame(userId = "user-1", lobbyId = lobbyId)
+
+        val error = assertThrows<IllegalStateException> {
+            service.startGame(userId = "user-1", lobbyId = lobbyId)
+        }
+
+        assertTrue(error.message.orEmpty().contains("not waiting"))
+    }
+
+    @Test
     fun `startGame rejects non-host users`() {
         val lobby = service.createLobby(user("user-1", "Alice"))
         service.joinLobby(user("user-2", "Bob"), lobby.joinCode!!)


### PR DESCRIPTION
## Summary
- Close the source lobby when a game reaches final game over so `/api/lobbies/current` no longer returns the stale lobby.
- Reject starting a game from a lobby that is no longer in `WAITING` state.
- Clear in-memory current-lobby mappings when a lobby is closed.
- Add regression coverage for finished-game lobby cleanup, stale `IN_GAME` restart prevention, and repository-free lobby cleanup.

Closes #35

## Test Plan
- [x] `./gradlew jacocoTestReport --rerun-tasks`