### PR TITLE
feat: online presence via heartbeat with TTL

### DIFF
--- a/src/main/kotlin/at/aau/se2/skyjo/SkyjoApplication.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/SkyjoApplication.kt
@@ -2,7 +2,9 @@ package at.aau.se2.skyjo
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
+@EnableScheduling
 @SpringBootApplication
 class SkyjoApplication
 

--- a/src/main/kotlin/at/aau/se2/skyjo/controller/FriendController.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/controller/FriendController.kt
@@ -39,6 +39,16 @@ class FriendController(
             ResponseEntity.ok(friendService.listFriends(user) as Any)
         }.getOrElse(::toSocialError)
 
+    @PostMapping("/api/social/heartbeat")
+    fun heartbeat(
+        @RequestHeader("Authorization") authorizationHeader: String?,
+    ): ResponseEntity<Any> =
+        runCatching {
+            val user = authSupport.requireUser(authorizationHeader)
+            friendService.recordHeartbeat(user)
+            ResponseEntity.noContent().build<Any>()
+        }.getOrElse(::toSocialError)
+
     @GetMapping("/api/friends/requests")
     fun listFriendRequests(
         @RequestHeader("Authorization") authorizationHeader: String?,

--- a/src/main/kotlin/at/aau/se2/skyjo/event/WebSocketEventListener.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/event/WebSocketEventListener.kt
@@ -10,9 +10,11 @@ import at.aau.se2.skyjo.service.LobbyService
 import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener
 import org.springframework.messaging.simp.SimpMessageSendingOperations
+import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.web.socket.messaging.SessionConnectedEvent
 import org.springframework.web.socket.messaging.SessionDisconnectEvent
+import java.util.concurrent.ConcurrentHashMap
 
 @Component
 class WebSocketEventListener(
@@ -23,21 +25,24 @@ class WebSocketEventListener(
 ) {
 
     private val logger = LoggerFactory.getLogger(WebSocketEventListener::class.java)
+    private val activeWebSocketSessionsByUser = ConcurrentHashMap<String, Int>()
 
     @EventListener
     fun handleWebSocketConnectListener(event: SessionConnectedEvent) {
         val userId = event.user?.name
         logger.info("New WebSocket connection: principal=$userId")
         if (userId != null) {
-            val currentLobbyId = runCatching { lobbyService.getCurrentLobbyForUser(userId)?.lobbyId }.getOrNull()
-            authService?.markUserConnected(userId, currentLobbyId)
+            markSessionConnected(userId)
+            refreshPresence(userId)
         }
     }
 
     @EventListener
     fun handleWebSocketDisconnectListener(event: SessionDisconnectEvent) {
         val playerId = event.user?.name ?: return
-        authService?.markUserDisconnected(playerId)
+        if (markSessionDisconnected(playerId)) {
+            authService?.markUserDisconnected(playerId)
+        }
         val disconnectedGameState = gameService?.markPlayerDisconnected(playerId)
         if (disconnectedGameState != null) {
             messagingTemplate.convertAndSend(disconnectedGameState.topicPath(), disconnectedGameState)
@@ -55,6 +60,42 @@ class WebSocketEventListener(
                 messagingTemplate.convertAndSend("/topic/lobbies/$code", updatedLobby.toUpdateMessage())
             }
         }
+    }
+
+    @Scheduled(fixedDelay = WEBSOCKET_PRESENCE_REFRESH_MS)
+    fun refreshActiveWebSocketPresence() {
+        activeWebSocketSessionsByUser.keys.forEach { userId ->
+            if ((activeWebSocketSessionsByUser[userId] ?: 0) > 0) {
+                refreshPresence(userId)
+            }
+        }
+    }
+
+    private fun refreshPresence(userId: String) {
+        val currentLobbyId = runCatching { lobbyService.getCurrentLobbyForUser(userId)?.lobbyId }.getOrNull()
+        authService?.markUserConnected(userId, currentLobbyId)
+    }
+
+    private fun markSessionConnected(userId: String) {
+        activeWebSocketSessionsByUser.compute(userId) { _, current -> (current ?: 0) + 1 }
+    }
+
+    private fun markSessionDisconnected(userId: String): Boolean {
+        var shouldMarkDisconnected = true
+        activeWebSocketSessionsByUser.compute(userId) { _, current ->
+            val next = (current ?: 1) - 1
+            if (next > 0) {
+                shouldMarkDisconnected = false
+                next
+            } else {
+                null
+            }
+        }
+        return shouldMarkDisconnected
+    }
+
+    private companion object {
+        const val WEBSOCKET_PRESENCE_REFRESH_MS = 20_000L
     }
 }
 

--- a/src/main/kotlin/at/aau/se2/skyjo/event/WebSocketEventListener.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/event/WebSocketEventListener.kt
@@ -10,6 +10,7 @@ import at.aau.se2.skyjo.service.LobbyService
 import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener
 import org.springframework.messaging.simp.SimpMessageSendingOperations
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.web.socket.messaging.SessionConnectedEvent
@@ -25,6 +26,7 @@ class WebSocketEventListener(
 ) {
 
     private val logger = LoggerFactory.getLogger(WebSocketEventListener::class.java)
+    private val activeWebSocketUsersBySessionId = ConcurrentHashMap<String, String>()
     private val activeWebSocketSessionsByUser = ConcurrentHashMap<String, Int>()
 
     @EventListener
@@ -32,7 +34,7 @@ class WebSocketEventListener(
         val userId = event.user?.name
         logger.info("New WebSocket connection: principal=$userId")
         if (userId != null) {
-            markSessionConnected(userId)
+            markSessionConnected(userId, event.sessionId())
             refreshPresence(userId)
         }
     }
@@ -40,8 +42,9 @@ class WebSocketEventListener(
     @EventListener
     fun handleWebSocketDisconnectListener(event: SessionDisconnectEvent) {
         val playerId = event.user?.name ?: return
-        if (markSessionDisconnected(playerId)) {
-            authService?.markUserDisconnected(playerId)
+        val disconnectedUserId = markSessionDisconnected(playerId, event.sessionId())
+        if (disconnectedUserId != null) {
+            authService?.markUserDisconnected(disconnectedUserId)
         }
         val disconnectedGameState = gameService?.markPlayerDisconnected(playerId)
         if (disconnectedGameState != null) {
@@ -76,23 +79,38 @@ class WebSocketEventListener(
         authService?.markUserConnected(userId, currentLobbyId)
     }
 
-    private fun markSessionConnected(userId: String) {
+    private fun markSessionConnected(userId: String, sessionId: String?) {
+        if (sessionId != null && activeWebSocketUsersBySessionId.putIfAbsent(sessionId, userId) != null) {
+            return
+        }
         activeWebSocketSessionsByUser.compute(userId) { _, current -> (current ?: 0) + 1 }
     }
 
-    private fun markSessionDisconnected(userId: String): Boolean {
-        var shouldMarkDisconnected = true
-        activeWebSocketSessionsByUser.compute(userId) { _, current ->
+    private fun markSessionDisconnected(userId: String, sessionId: String?): String? {
+        val countedUserId = if (sessionId == null) {
+            userId
+        } else {
+            activeWebSocketUsersBySessionId.remove(sessionId) ?: return null
+        }
+
+        var shouldMarkDisconnected = false
+        activeWebSocketSessionsByUser.compute(countedUserId) { _, current ->
             val next = (current ?: 1) - 1
             if (next > 0) {
-                shouldMarkDisconnected = false
                 next
             } else {
+                shouldMarkDisconnected = true
                 null
             }
         }
-        return shouldMarkDisconnected
+        return if (shouldMarkDisconnected) countedUserId else null
     }
+
+    private fun SessionConnectedEvent.sessionId(): String? =
+        runCatching { SimpMessageHeaderAccessor.getSessionId(message.headers) }.getOrNull()
+
+    private fun SessionDisconnectEvent.sessionId(): String? =
+        runCatching { sessionId }.getOrNull()
 
     private companion object {
         const val WEBSOCKET_PRESENCE_REFRESH_MS = 20_000L

--- a/src/main/kotlin/at/aau/se2/skyjo/event/WebSocketEventListener.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/event/WebSocketEventListener.kt
@@ -42,10 +42,8 @@ class WebSocketEventListener(
     @EventListener
     fun handleWebSocketDisconnectListener(event: SessionDisconnectEvent) {
         val playerId = event.user?.name ?: return
-        val disconnectedUserId = markSessionDisconnected(playerId, event.sessionId())
-        if (disconnectedUserId != null) {
-            authService?.markUserDisconnected(disconnectedUserId)
-        }
+        val disconnectedUserId = markSessionDisconnected(playerId, event.sessionId()) ?: return
+        authService?.markUserDisconnected(disconnectedUserId)
         val disconnectedGameState = gameService?.markPlayerDisconnected(playerId)
         if (disconnectedGameState != null) {
             messagingTemplate.convertAndSend(disconnectedGameState.topicPath(), disconnectedGameState)

--- a/src/main/kotlin/at/aau/se2/skyjo/event/WebSocketEventListener.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/event/WebSocketEventListener.kt
@@ -28,21 +28,28 @@ class WebSocketEventListener(
     private val logger = LoggerFactory.getLogger(WebSocketEventListener::class.java)
     private val activeWebSocketUsersBySessionId = ConcurrentHashMap<String, String>()
     private val activeWebSocketSessionsByUser = ConcurrentHashMap<String, Int>()
+    private val authenticatedLobbyIdsBySessionId = ConcurrentHashMap<String, String>()
 
     @EventListener
     fun handleWebSocketConnectListener(event: SessionConnectedEvent) {
         val userId = event.user?.name
         logger.info("New WebSocket connection: principal=$userId")
         if (userId != null) {
-            markSessionConnected(userId, event.sessionId())
-            refreshPresence(userId)
+            val sessionId = event.sessionId()
+            markSessionConnected(userId, sessionId)
+            val lobbyId = refreshPresence(userId)
+            if (sessionId != null && lobbyId != null) {
+                authenticatedLobbyIdsBySessionId[sessionId] = lobbyId
+            }
         }
     }
 
     @EventListener
     fun handleWebSocketDisconnectListener(event: SessionDisconnectEvent) {
         val playerId = event.user?.name ?: return
-        val disconnectedUserId = markSessionDisconnected(playerId, event.sessionId()) ?: return
+        val sessionId = event.sessionId()
+        val sessionLobbyId = sessionId?.let(authenticatedLobbyIdsBySessionId::remove)
+        val disconnectedUserId = markSessionDisconnected(playerId, sessionId) ?: return
         authService?.markUserDisconnected(disconnectedUserId)
         val disconnectedGameState = gameService?.markPlayerDisconnected(playerId)
         if (disconnectedGameState != null) {
@@ -53,8 +60,14 @@ class WebSocketEventListener(
             logger.info("Player disconnected and removed from lobby: $playerId")
             messagingTemplate.convertAndSend("/topic/lobby", updatedState.toUpdateMessage())
         }
-        val authenticatedLobby = runCatching { lobbyService.getCurrentLobbyForUser(playerId) }.getOrNull()
-        if (authenticatedLobby?.lobbyId != null) {
+        val authenticatedLobby = if (sessionId == null) {
+            runCatching { lobbyService.getCurrentLobbyForUser(playerId) }.getOrNull()
+        } else {
+            sessionLobbyId?.let { lobbyId ->
+                runCatching { lobbyService.getLobbyById(lobbyId) }.getOrNull()
+            }
+        }
+        if (authenticatedLobby?.lobbyId != null && authenticatedLobby.players.any { it.userId == playerId }) {
             val updatedLobby = lobbyService.leaveLobby(playerId, authenticatedLobby.lobbyId)
             logger.info("Authenticated player disconnected and removed from lobby: $playerId")
             updatedLobby.joinCode?.let { code ->
@@ -72,9 +85,10 @@ class WebSocketEventListener(
         }
     }
 
-    private fun refreshPresence(userId: String) {
+    private fun refreshPresence(userId: String): String? {
         val currentLobbyId = runCatching { lobbyService.getCurrentLobbyForUser(userId)?.lobbyId }.getOrNull()
         authService?.markUserConnected(userId, currentLobbyId)
+        return currentLobbyId
     }
 
     private fun markSessionConnected(userId: String, sessionId: String?) {

--- a/src/main/kotlin/at/aau/se2/skyjo/persistence/AuthRepository.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/persistence/AuthRepository.kt
@@ -90,7 +90,7 @@ class AuthRepository(private val jdbc: JdbcTemplate) {
             )
             """.trimIndent()
         )
-        runCatching {
+        if (!userPresenceHasLastSeenAtColumn()) {
             jdbc.execute("ALTER TABLE user_presence ADD COLUMN last_seen_at INTEGER NOT NULL DEFAULT 0")
         }
     }
@@ -327,4 +327,10 @@ class AuthRepository(private val jdbc: JdbcTemplate) {
         val value = getLong(column)
         return if (wasNull()) null else value
     }
+
+    private fun userPresenceHasLastSeenAtColumn(): Boolean =
+        jdbc.query(
+            "PRAGMA table_info(user_presence)",
+            { rs, _ -> rs.getString("name") },
+        ).any { it == "last_seen_at" }
 }

--- a/src/main/kotlin/at/aau/se2/skyjo/persistence/AuthRepository.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/persistence/AuthRepository.kt
@@ -34,6 +34,7 @@ data class UserPresenceRecord(
     val connected: Boolean,
     val currentLobbyId: String?,
     val updatedAt: Long,
+    val lastSeenAt: Long,
 )
 
 @Repository
@@ -84,10 +85,14 @@ class AuthRepository(private val jdbc: JdbcTemplate) {
                 connected INTEGER NOT NULL DEFAULT 0,
                 current_lobby_id TEXT,
                 updated_at INTEGER NOT NULL,
+                last_seen_at INTEGER NOT NULL DEFAULT 0,
                 FOREIGN KEY(user_id) REFERENCES users(user_id)
             )
             """.trimIndent()
         )
+        runCatching {
+            jdbc.execute("ALTER TABLE user_presence ADD COLUMN last_seen_at INTEGER NOT NULL DEFAULT 0")
+        }
     }
 
     fun createUser(userId: String, username: String, passwordHash: String, now: Long) {
@@ -240,16 +245,18 @@ class AuthRepository(private val jdbc: JdbcTemplate) {
     fun setPresence(userId: String, connected: Boolean, currentLobbyId: String?, now: Long) {
         jdbc.update(
             """
-            INSERT INTO user_presence (user_id, connected, current_lobby_id, updated_at)
-            VALUES (?, ?, ?, ?)
+            INSERT INTO user_presence (user_id, connected, current_lobby_id, updated_at, last_seen_at)
+            VALUES (?, ?, ?, ?, ?)
             ON CONFLICT(user_id) DO UPDATE SET
                 connected = excluded.connected,
                 current_lobby_id = excluded.current_lobby_id,
-                updated_at = excluded.updated_at
+                updated_at = excluded.updated_at,
+                last_seen_at = excluded.last_seen_at
             """.trimIndent(),
             userId,
             if (connected) 1 else 0,
             currentLobbyId,
+            now,
             now,
         )
     }
@@ -262,13 +269,15 @@ class AuthRepository(private val jdbc: JdbcTemplate) {
     fun touchPresence(userId: String, now: Long) {
         jdbc.update(
             """
-            INSERT INTO user_presence (user_id, connected, current_lobby_id, updated_at)
-            VALUES (?, 1, NULL, ?)
+            INSERT INTO user_presence (user_id, connected, current_lobby_id, updated_at, last_seen_at)
+            VALUES (?, 1, NULL, ?, ?)
             ON CONFLICT(user_id) DO UPDATE SET
                 connected = 1,
-                updated_at = excluded.updated_at
+                updated_at = excluded.updated_at,
+                last_seen_at = excluded.last_seen_at
             """.trimIndent(),
             userId,
+            now,
             now,
         )
     }
@@ -289,7 +298,7 @@ class AuthRepository(private val jdbc: JdbcTemplate) {
     fun getPresence(userId: String): UserPresenceRecord? =
         jdbc.query(
             """
-            SELECT user_id, connected, current_lobby_id, updated_at
+            SELECT user_id, connected, current_lobby_id, updated_at, last_seen_at
             FROM user_presence
             WHERE user_id = ?
             """.trimIndent(),
@@ -299,6 +308,7 @@ class AuthRepository(private val jdbc: JdbcTemplate) {
                     connected = rs.getInt("connected") == 1,
                     currentLobbyId = rs.getString("current_lobby_id"),
                     updatedAt = rs.getLong("updated_at"),
+                    lastSeenAt = rs.getLong("last_seen_at"),
                 )
             },
             userId,

--- a/src/main/kotlin/at/aau/se2/skyjo/persistence/AuthRepository.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/persistence/AuthRepository.kt
@@ -254,6 +254,25 @@ class AuthRepository(private val jdbc: JdbcTemplate) {
         )
     }
 
+    /**
+     * Refreshes a user's presence without clobbering their current lobby. Used by the
+     * foreground heartbeat so a user counts as online while in the app, even when not
+     * connected to a lobby websocket.
+     */
+    fun touchPresence(userId: String, now: Long) {
+        jdbc.update(
+            """
+            INSERT INTO user_presence (user_id, connected, current_lobby_id, updated_at)
+            VALUES (?, 1, NULL, ?)
+            ON CONFLICT(user_id) DO UPDATE SET
+                connected = 1,
+                updated_at = excluded.updated_at
+            """.trimIndent(),
+            userId,
+            now,
+        )
+    }
+
     fun clearCurrentLobby(lobbyId: String, now: Long) {
         jdbc.update(
             """

--- a/src/main/kotlin/at/aau/se2/skyjo/persistence/FriendRepository.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/persistence/FriendRepository.kt
@@ -168,10 +168,17 @@ class FriendRepository(private val jdbc: JdbcTemplate) {
             friendUserId,
         ) != 0
 
-    fun listFriends(userId: String): List<FriendUserRecord> =
+    /**
+     * Lists a user's friends. A friend counts as online only when their presence is
+     * connected AND was refreshed at or after [onlineSince] (now minus the presence TTL),
+     * so stale presence rows from crashed/backgrounded clients no longer read as online.
+     */
+    fun listFriends(userId: String, onlineSince: Long): List<FriendUserRecord> =
         jdbc.query(
             """
-            SELECT u.user_id, u.username, COALESCE(p.connected, 0) AS connected, p.current_lobby_id
+            SELECT u.user_id, u.username,
+                   CASE WHEN p.connected = 1 AND p.updated_at >= ? THEN 1 ELSE 0 END AS connected,
+                   p.current_lobby_id
             FROM friendships f
             JOIN users u ON u.user_id = f.friend_user_id
             LEFT JOIN user_presence p ON p.user_id = u.user_id
@@ -179,6 +186,7 @@ class FriendRepository(private val jdbc: JdbcTemplate) {
             ORDER BY u.username COLLATE NOCASE ASC
             """.trimIndent(),
             ::toFriendUserRecord,
+            onlineSince,
             userId,
         )
 

--- a/src/main/kotlin/at/aau/se2/skyjo/persistence/FriendRepository.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/persistence/FriendRepository.kt
@@ -172,13 +172,14 @@ class FriendRepository(private val jdbc: JdbcTemplate) {
      * Lists a user's friends. A friend counts as online only when their presence is
      * connected AND was refreshed at or after [onlineSince] (now minus the presence TTL),
      * so stale presence rows from crashed/backgrounded clients no longer read as online.
+     * Lobby ids are hidden under the same freshness check to avoid exposing stale lobbies.
      */
     fun listFriends(userId: String, onlineSince: Long): List<FriendUserRecord> =
         jdbc.query(
             """
             SELECT u.user_id, u.username,
-                   CASE WHEN p.connected = 1 AND p.updated_at >= ? THEN 1 ELSE 0 END AS connected,
-                   p.current_lobby_id
+                   CASE WHEN p.connected = 1 AND p.last_seen_at >= ? THEN 1 ELSE 0 END AS connected,
+                   CASE WHEN p.connected = 1 AND p.last_seen_at >= ? THEN p.current_lobby_id ELSE NULL END AS current_lobby_id
             FROM friendships f
             JOIN users u ON u.user_id = f.friend_user_id
             LEFT JOIN user_presence p ON p.user_id = u.user_id
@@ -186,6 +187,7 @@ class FriendRepository(private val jdbc: JdbcTemplate) {
             ORDER BY u.username COLLATE NOCASE ASC
             """.trimIndent(),
             ::toFriendUserRecord,
+            onlineSince,
             onlineSince,
             userId,
         )

--- a/src/main/kotlin/at/aau/se2/skyjo/service/FriendService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/FriendService.kt
@@ -59,7 +59,11 @@ class FriendService @Autowired constructor(
     }
 
     fun listFriends(user: AuthUserDto): List<FriendDto> =
-        repository.listFriends(user.userId).map { it.toFriendDto() }
+        repository.listFriends(user.userId, onlineSince = nowProvider() - PRESENCE_TTL_MS).map { it.toFriendDto() }
+
+    fun recordHeartbeat(user: AuthUserDto) {
+        authRepository.touchPresence(user.userId, nowProvider())
+    }
 
     fun listFriendRequests(user: AuthUserDto): FriendRequestsResponse =
         FriendRequestsResponse(
@@ -150,5 +154,12 @@ class FriendService @Autowired constructor(
 
     private companion object {
         const val SEARCH_LIMIT = 20
+
+        /**
+         * How long a presence row stays "online" after its last refresh. Clients send a
+         * heartbeat roughly every 20s while foregrounded; this leaves room for one missed
+         * beat before a friend is shown offline.
+         */
+        const val PRESENCE_TTL_MS = 60_000L
     }
 }

--- a/src/main/kotlin/at/aau/se2/skyjo/service/LobbyAdmission.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/LobbyAdmission.kt
@@ -1,0 +1,18 @@
+package at.aau.se2.skyjo.service
+
+import at.aau.se2.skyjo.model.lobby.LobbyState
+import at.aau.se2.skyjo.model.lobby.LobbyStatus
+
+internal fun LobbyState.requireOpenForNewPlayers(operation: String) {
+    when (status) {
+        LobbyStatus.IN_GAME -> error("cannot $operation: game already in progress")
+        LobbyStatus.CLOSED -> error("cannot $operation: lobby is closed")
+        else -> Unit
+    }
+}
+
+internal fun LobbyState.requireAvailableSlot(operation: String) {
+    if (players.size >= maxPlayers) {
+        error("cannot $operation: lobby is full (max $maxPlayers players)")
+    }
+}

--- a/src/main/kotlin/at/aau/se2/skyjo/service/LobbyInviteService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/LobbyInviteService.kt
@@ -1,7 +1,6 @@
 package at.aau.se2.skyjo.service
 
 import at.aau.se2.skyjo.model.auth.AuthUserDto
-import at.aau.se2.skyjo.model.lobby.LobbyStatus
 import at.aau.se2.skyjo.model.social.LobbyInviteDto
 import at.aau.se2.skyjo.model.social.LobbyInviteStatus
 import at.aau.se2.skyjo.model.social.RelationshipStatus
@@ -54,15 +53,14 @@ class LobbyInviteService @Autowired constructor(
             error("only friends can be invited")
         }
         val lobby = lobbyService.getLobbyById(lobbyId) ?: error("lobby not found")
-        if (lobby.status != LobbyStatus.WAITING) {
-            error("cannot invite to a lobby that is not waiting")
-        }
+        lobby.requireOpenForNewPlayers("invite")
         if (lobby.players.none { it.userId == from.userId }) {
             error("only a lobby member can invite")
         }
         if (lobby.players.any { it.userId == toUserId }) {
             error("user is already in the lobby")
         }
+        lobby.requireAvailableSlot("invite")
         if (repository.findPendingInvite(lobbyId, toUserId) != null) {
             error("lobby invite already exists")
         }
@@ -84,9 +82,7 @@ class LobbyInviteService @Autowired constructor(
     fun acceptInvite(user: AuthUserDto, inviteId: String): LobbyInviteDto {
         val invite = requirePendingInviteForUser(user, inviteId)
         val lobby = lobbyService.getLobbyById(invite.lobbyId) ?: error("lobby not found")
-        if (lobby.status != LobbyStatus.WAITING) {
-            error("cannot accept invite for a lobby that is not waiting")
-        }
+        lobby.requireOpenForNewPlayers("accept invite")
 
         lobbyService.joinLobby(user, invite.joinCode)
         return repository.updateInviteStatus(inviteId, LobbyInviteStatus.ACCEPTED, nowProvider())?.toDto(user.userId)

--- a/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
@@ -129,7 +129,6 @@ class LobbyService(
 
     fun joinLobby(user: AuthUserDto, joinCode: String): LobbyState = lock.withLock {
         val lobby = getLobbyByJoinCode(joinCode) ?: error("lobby not found")
-        lobby.requireOpenForNewPlayers("join")
         val existingLobby = getCurrentLobbyForUser(user.userId)
         if (existingLobby != null && existingLobby.lobbyId != lobby.lobbyId) {
             error("user is already in a lobby")
@@ -137,6 +136,7 @@ class LobbyService(
         if (lobby.players.any { it.userId == user.userId }) {
             return lobby
         }
+        lobby.requireOpenForNewPlayers("join")
         lobby.requireAvailableSlot("join")
 
         val lobbyId = lobby.lobbyId ?: error("lobby id is missing")

--- a/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/LobbyService.kt
@@ -48,15 +48,11 @@ class LobbyService(
     private val inMemoryUserLobbyIds = mutableMapOf<String, String>()
 
     fun join(sessionId: String, nickname: String): LobbyState = lock.withLock {
-        if (state.status == LobbyStatus.IN_GAME) {
-            error("cannot join: game already in progress")
-        }
-        if (state.players.size >= state.maxPlayers) {
-            error("cannot join: lobby is full (max ${state.maxPlayers} players)")
-        }
+        state.requireOpenForNewPlayers("join")
         if (state.players.any { it.sessionId == sessionId }) {
             return state
         }
+        state.requireAvailableSlot("join")
 
         val isHost = state.players.isEmpty()
         val player = LobbyPlayer(sessionId = sessionId, nickname = nickname, isHost = isHost)
@@ -133,9 +129,7 @@ class LobbyService(
 
     fun joinLobby(user: AuthUserDto, joinCode: String): LobbyState = lock.withLock {
         val lobby = getLobbyByJoinCode(joinCode) ?: error("lobby not found")
-        if (lobby.status != LobbyStatus.WAITING) {
-            error("cannot join: lobby is not waiting")
-        }
+        lobby.requireOpenForNewPlayers("join")
         val existingLobby = getCurrentLobbyForUser(user.userId)
         if (existingLobby != null && existingLobby.lobbyId != lobby.lobbyId) {
             error("user is already in a lobby")
@@ -143,9 +137,7 @@ class LobbyService(
         if (lobby.players.any { it.userId == user.userId }) {
             return lobby
         }
-        if (lobby.players.size >= lobby.maxPlayers) {
-            error("cannot join: lobby is full (max ${lobby.maxPlayers} players)")
-        }
+        lobby.requireAvailableSlot("join")
 
         val lobbyId = lobby.lobbyId ?: error("lobby id is missing")
         val now = nowProvider()

--- a/src/test/kotlin/at/aau/se2/skyjo/controller/FriendControllerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/controller/FriendControllerTest.kt
@@ -14,6 +14,7 @@ import at.aau.se2.skyjo.service.UnauthorizedException
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
 
@@ -59,6 +60,25 @@ class FriendControllerTest {
 
         assertEquals(HttpStatus.OK, result.statusCode)
         assertEquals("Bob", (result.body as List<*>).filterIsInstance<FriendDto>().single().username)
+    }
+
+    @Test
+    fun `heartbeat records presence and returns no content`() {
+        whenever(authService.requireUser("token")).thenReturn(user())
+
+        val result = controller.heartbeat("Bearer token")
+
+        assertEquals(HttpStatus.NO_CONTENT, result.statusCode)
+        verify(friendService).recordHeartbeat(user())
+    }
+
+    @Test
+    fun `heartbeat returns unauthorized for invalid token`() {
+        whenever(authService.requireUser("bad")).thenThrow(UnauthorizedException())
+
+        val result = controller.heartbeat("Bearer bad")
+
+        assertEquals(HttpStatus.UNAUTHORIZED, result.statusCode)
     }
 
     @Test

--- a/src/test/kotlin/at/aau/se2/skyjo/event/WebSocketEvebtListenerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/event/WebSocketEvebtListenerTest.kt
@@ -134,6 +134,23 @@ class WebSocketEventListenerTest {
         }
 
         @Test
+        fun `disconnect for one of multiple websocket sessions does not leave game or lobby`() {
+            val listenerWithGame = WebSocketEventListener(messagingTemplate, lobbyService, gameService, authService)
+            every { principal.name } returns playerId
+            every { lobbyService.getCurrentLobbyForUser(playerId) } returns null
+            listenerWithGame.handleWebSocketConnectListener(connectedEvent("session-1"))
+            listenerWithGame.handleWebSocketConnectListener(connectedEvent("session-2"))
+            clearMocks(authService, gameService, lobbyService, messagingTemplate)
+
+            listenerWithGame.handleWebSocketDisconnectListener(disconnectEvent("session-1"))
+
+            verify(exactly = 0) { authService.markUserDisconnected(any()) }
+            verify { gameService wasNot Called }
+            verify { lobbyService wasNot Called }
+            verify { messagingTemplate wasNot Called }
+        }
+
+        @Test
         fun `wirft keinen Fehler, wenn User null ist`() {
             val event = mockk<SessionConnectedEvent>()
             every { event.user } returns null

--- a/src/test/kotlin/at/aau/se2/skyjo/event/WebSocketEvebtListenerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/event/WebSocketEvebtListenerTest.kt
@@ -77,6 +77,42 @@ class WebSocketEventListenerTest {
         }
 
         @Test
+        fun `refreshes active websocket presence periodically`() {
+            val event = mockk<SessionConnectedEvent>()
+            every { event.user } returns principal
+            every { principal.name } returns playerId
+            every { lobbyService.getCurrentLobbyForUser(playerId) } returns null
+            listener.handleWebSocketConnectListener(event)
+            clearMocks(authService)
+            every { lobbyService.getCurrentLobbyForUser(playerId) } returns LobbyState(
+                lobbyId = "lobby-2",
+                joinCode = "XYZ789",
+            )
+
+            listener.refreshActiveWebSocketPresence()
+
+            verify { authService.markUserConnected(playerId, "lobby-2") }
+        }
+
+        @Test
+        fun `does not refresh disconnected websocket sessions`() {
+            val connectEvent = mockk<SessionConnectedEvent>()
+            val disconnectEvent = mockk<SessionDisconnectEvent>()
+            every { connectEvent.user } returns principal
+            every { disconnectEvent.user } returns principal
+            every { principal.name } returns playerId
+            every { lobbyService.getCurrentLobbyForUser(playerId) } returns null
+            every { lobbyService.isPlayerInLobby(playerId) } returns false
+            listener.handleWebSocketConnectListener(connectEvent)
+            listener.handleWebSocketDisconnectListener(disconnectEvent)
+            clearMocks(authService)
+
+            listener.refreshActiveWebSocketPresence()
+
+            verify(exactly = 0) { authService.markUserConnected(any(), any()) }
+        }
+
+        @Test
         fun `wirft keinen Fehler, wenn User null ist`() {
             val event = mockk<SessionConnectedEvent>()
             every { event.user } returns null

--- a/src/test/kotlin/at/aau/se2/skyjo/event/WebSocketEvebtListenerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/event/WebSocketEvebtListenerTest.kt
@@ -151,6 +151,51 @@ class WebSocketEventListenerTest {
         }
 
         @Test
+        fun `disconnecting invite-only socket does not close lobby created after socket connected`() {
+            every { principal.name } returns playerId
+            every { lobbyService.getCurrentLobbyForUser(playerId) } returns null
+            listener.handleWebSocketConnectListener(connectedEvent("invite-session"))
+
+            val newlyCreatedLobby = LobbyState(
+                lobbyId = "lobby-1",
+                joinCode = "ABC123",
+                players = listOf(
+                    LobbyPlayer(sessionId = playerId, nickname = "Alice", isHost = true, userId = playerId),
+                ),
+            )
+            every { lobbyService.getCurrentLobbyForUser(playerId) } returns newlyCreatedLobby
+            every { lobbyService.isPlayerInLobby(playerId) } returns false
+
+            listener.handleWebSocketDisconnectListener(disconnectEvent("invite-session"))
+
+            verify(exactly = 0) { lobbyService.leaveLobby(any(), any()) }
+            verify(exactly = 0) { lobbyService.getLobbyById(any()) }
+        }
+
+        @Test
+        fun `disconnecting lobby socket removes player from lobby associated at connect time`() {
+            val lobby = LobbyState(
+                lobbyId = "lobby-1",
+                joinCode = "ABC123",
+                players = listOf(
+                    LobbyPlayer(sessionId = playerId, nickname = "Alice", isHost = true, userId = playerId),
+                ),
+            )
+            val closedLobby = lobby.copy(players = emptyList(), status = LobbyStatus.CLOSED)
+            every { principal.name } returns playerId
+            every { lobbyService.getCurrentLobbyForUser(playerId) } returns lobby
+            every { lobbyService.getLobbyById("lobby-1") } returns lobby
+            every { lobbyService.isPlayerInLobby(playerId) } returns false
+            every { lobbyService.leaveLobby(playerId, "lobby-1") } returns closedLobby
+            listener.handleWebSocketConnectListener(connectedEvent("lobby-session"))
+
+            listener.handleWebSocketDisconnectListener(disconnectEvent("lobby-session"))
+
+            verify { lobbyService.leaveLobby(playerId, "lobby-1") }
+            verify { messagingTemplate.convertAndSend("/topic/lobbies/ABC123", any<LobbyUpdateMessage>()) }
+        }
+
+        @Test
         fun `wirft keinen Fehler, wenn User null ist`() {
             val event = mockk<SessionConnectedEvent>()
             every { event.user } returns null

--- a/src/test/kotlin/at/aau/se2/skyjo/event/WebSocketEvebtListenerTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/event/WebSocketEvebtListenerTest.kt
@@ -8,7 +8,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor
 import org.springframework.messaging.simp.SimpMessageSendingOperations
+import org.springframework.messaging.support.MessageBuilder
 import org.springframework.web.socket.messaging.SessionConnectedEvent
 import org.springframework.web.socket.messaging.SessionDisconnectEvent
 import java.security.Principal
@@ -110,6 +112,25 @@ class WebSocketEventListenerTest {
             listener.refreshActiveWebSocketPresence()
 
             verify(exactly = 0) { authService.markUserConnected(any(), any()) }
+        }
+
+        @Test
+        fun `duplicate disconnect for one websocket session does not clear another active session`() {
+            every { principal.name } returns playerId
+            every { lobbyService.getCurrentLobbyForUser(playerId) } returns null
+            every { lobbyService.isPlayerInLobby(playerId) } returns false
+            listener.handleWebSocketConnectListener(connectedEvent("session-1"))
+            listener.handleWebSocketConnectListener(connectedEvent("session-2"))
+            clearMocks(authService)
+
+            listener.handleWebSocketDisconnectListener(disconnectEvent("session-1"))
+            listener.handleWebSocketDisconnectListener(disconnectEvent("session-1"))
+
+            verify(exactly = 0) { authService.markUserDisconnected(playerId) }
+
+            listener.handleWebSocketDisconnectListener(disconnectEvent("session-2"))
+
+            verify(exactly = 1) { authService.markUserDisconnected(playerId) }
         }
 
         @Test
@@ -286,4 +307,21 @@ class WebSocketEventListenerTest {
             verify { messagingTemplate.convertAndSend("/topic/lobbies/XYZ789", any<LobbyUpdateMessage>()) }
         }
     }
+
+    private fun connectedEvent(sessionId: String): SessionConnectedEvent =
+        mockk<SessionConnectedEvent> {
+            every { user } returns principal
+            every { message } returns MessageBuilder.createMessage(
+                ByteArray(0),
+                SimpMessageHeaderAccessor.create().apply {
+                    setSessionId(sessionId)
+                }.messageHeaders,
+            )
+        }
+
+    private fun disconnectEvent(sessionId: String): SessionDisconnectEvent =
+        mockk<SessionDisconnectEvent> {
+            every { user } returns principal
+            every { getSessionId() } returns sessionId
+        }
 }

--- a/src/test/kotlin/at/aau/se2/skyjo/persistence/AuthRepositoryTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/persistence/AuthRepositoryTest.kt
@@ -126,6 +126,40 @@ class AuthRepositoryTest {
     }
 
     @Test
+    fun `initSchema migrates legacy presence table with last seen column`() {
+        val dataSource = SingleConnectionDataSource("jdbc:sqlite::memory:", true)
+        val jdbc = JdbcTemplate(dataSource)
+        jdbc.execute(
+            """
+            CREATE TABLE user_presence (
+                user_id TEXT PRIMARY KEY,
+                connected INTEGER NOT NULL DEFAULT 0,
+                current_lobby_id TEXT,
+                updated_at INTEGER NOT NULL
+            )
+            """.trimIndent(),
+        )
+        jdbc.update(
+            """
+            INSERT INTO user_presence (user_id, connected, current_lobby_id, updated_at)
+            VALUES (?, 1, ?, ?)
+            """.trimIndent(),
+            "user-legacy",
+            "lobby-1",
+            2_000L,
+        )
+
+        val legacyRepo = AuthRepository(jdbc)
+        legacyRepo.initSchema()
+
+        val presence = legacyRepo.getPresence("user-legacy")
+        assertTrue(presence?.connected == true)
+        assertEquals("lobby-1", presence?.currentLobbyId)
+        assertEquals(2_000L, presence?.updatedAt)
+        assertEquals(0L, presence?.lastSeenAt)
+    }
+
+    @Test
     fun `current lobby can be cleared without changing presence state`() {
         repo.createUser("user-1", "Alice", "hash", now = 1_000L)
         repo.createUser("user-2", "Bob", "hash", now = 1_000L)

--- a/src/test/kotlin/at/aau/se2/skyjo/persistence/AuthRepositoryTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/persistence/AuthRepositoryTest.kt
@@ -119,8 +119,10 @@ class AuthRepositoryTest {
 
         assertTrue(online?.connected == true)
         assertEquals("lobby-1", online?.currentLobbyId)
+        assertEquals(2_000L, online?.lastSeenAt)
         assertFalse(offline?.connected == true)
         assertNull(offline?.currentLobbyId)
+        assertEquals(3_000L, offline?.lastSeenAt)
     }
 
     @Test
@@ -137,7 +139,9 @@ class AuthRepositoryTest {
         assertTrue(cleared?.connected == true)
         assertNull(cleared?.currentLobbyId)
         assertEquals(3_000L, cleared?.updatedAt)
+        assertEquals(2_000L, cleared?.lastSeenAt)
         assertEquals("lobby-2", unchanged?.currentLobbyId)
         assertEquals(2_000L, unchanged?.updatedAt)
+        assertEquals(2_000L, unchanged?.lastSeenAt)
     }
 }

--- a/src/test/kotlin/at/aau/se2/skyjo/persistence/FriendRepositoryTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/persistence/FriendRepositoryTest.kt
@@ -2,6 +2,7 @@ package at.aau.se2.skyjo.persistence
 
 import at.aau.se2.skyjo.model.social.FriendRequestStatus
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -51,11 +52,46 @@ class FriendRepositoryTest {
         repository.createFriendship("user-b", "user-a", now = 1_000L)
         authRepository.setPresence("user-b", connected = true, currentLobbyId = "lobby-1", now = 2_000L)
 
-        val friends = repository.listFriends("user-a")
+        val friends = repository.listFriends("user-a", onlineSince = 1_500L)
 
         assertEquals("Bob", friends.single().username)
         assertTrue(friends.single().online)
         assertEquals("lobby-1", friends.single().currentLobbyId)
+    }
+
+    @Test
+    fun `listFriends reports stale presence as offline`() {
+        repository.createFriendship("user-a", "user-b", now = 1_000L)
+        repository.createFriendship("user-b", "user-a", now = 1_000L)
+        authRepository.setPresence("user-b", connected = true, currentLobbyId = null, now = 2_000L)
+
+        val friends = repository.listFriends("user-a", onlineSince = 5_000L)
+
+        assertFalse(friends.single().online)
+    }
+
+    @Test
+    fun `touchPresence keeps friend online without clobbering current lobby`() {
+        repository.createFriendship("user-a", "user-b", now = 1_000L)
+        repository.createFriendship("user-b", "user-a", now = 1_000L)
+        authRepository.setPresence("user-b", connected = true, currentLobbyId = "lobby-1", now = 2_000L)
+
+        authRepository.touchPresence("user-b", now = 9_000L)
+        val friends = repository.listFriends("user-a", onlineSince = 8_000L)
+
+        assertTrue(friends.single().online)
+        assertEquals("lobby-1", friends.single().currentLobbyId)
+    }
+
+    @Test
+    fun `touchPresence marks a user online on first contact`() {
+        repository.createFriendship("user-a", "user-b", now = 1_000L)
+        repository.createFriendship("user-b", "user-a", now = 1_000L)
+
+        authRepository.touchPresence("user-b", now = 9_000L)
+        val friends = repository.listFriends("user-a", onlineSince = 8_000L)
+
+        assertTrue(friends.single().online)
     }
 
     private fun createUser(userId: String, username: String) {

--- a/src/test/kotlin/at/aau/se2/skyjo/persistence/FriendRepositoryTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/persistence/FriendRepositoryTest.kt
@@ -3,6 +3,7 @@ package at.aau.se2.skyjo.persistence
 import at.aau.se2.skyjo.model.social.FriendRequestStatus
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -63,11 +64,25 @@ class FriendRepositoryTest {
     fun `listFriends reports stale presence as offline`() {
         repository.createFriendship("user-a", "user-b", now = 1_000L)
         repository.createFriendship("user-b", "user-a", now = 1_000L)
-        authRepository.setPresence("user-b", connected = true, currentLobbyId = null, now = 2_000L)
+        authRepository.setPresence("user-b", connected = true, currentLobbyId = "lobby-1", now = 2_000L)
 
         val friends = repository.listFriends("user-a", onlineSince = 5_000L)
 
         assertFalse(friends.single().online)
+        assertNull(friends.single().currentLobbyId)
+    }
+
+    @Test
+    fun `listFriends does not refresh online state from non-presence row updates`() {
+        repository.createFriendship("user-a", "user-b", now = 1_000L)
+        repository.createFriendship("user-b", "user-a", now = 1_000L)
+        authRepository.setPresence("user-b", connected = true, currentLobbyId = "lobby-1", now = 2_000L)
+
+        authRepository.clearCurrentLobby("lobby-1", now = 9_000L)
+        val friends = repository.listFriends("user-a", onlineSince = 5_000L)
+
+        assertFalse(friends.single().online)
+        assertNull(friends.single().currentLobbyId)
     }
 
     @Test

--- a/src/test/kotlin/at/aau/se2/skyjo/service/FriendServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/FriendServiceTest.kt
@@ -84,6 +84,42 @@ class FriendServiceTest {
     }
 
     @Test
+    fun `recordHeartbeat marks the user online in their friends list`() {
+        val request = service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+        service.acceptFriendRequest(user("user-b", "Bob"), request.requestId)
+
+        service.recordHeartbeat(user("user-b", "Bob"))
+
+        assertTrue(service.listFriends(user("user-a", "Alice")).single { it.username == "Bob" }.online)
+    }
+
+    @Test
+    fun `listFriends reports a friend without presence as offline`() {
+        val request = service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+        service.acceptFriendRequest(user("user-b", "Bob"), request.requestId)
+
+        assertEquals(false, service.listFriends(user("user-a", "Alice")).single().online)
+    }
+
+    @Test
+    fun `listFriends reports a friend as offline once heartbeat is older than the TTL`() {
+        val request = service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
+        service.acceptFriendRequest(user("user-b", "Bob"), request.requestId)
+        service.recordHeartbeat(user("user-b", "Bob")) // recorded at now = 1_000L
+
+        val laterService = FriendService(
+            repository = repository,
+            authRepository = authRepository,
+            requestIdGenerator = object : FriendRequestIdGenerator {
+                override fun generateId(): String = "unused"
+            },
+            nowProvider = { 1_000_000L },
+        )
+
+        assertEquals(false, laterService.listFriends(user("user-a", "Alice")).single().online)
+    }
+
+    @Test
     fun `sendFriendRequest rejects duplicate friendship`() {
         val request = service.sendFriendRequest(user("user-a", "Alice"), toUserId = "user-b")
         service.acceptFriendRequest(user("user-b", "Bob"), request.requestId)

--- a/src/test/kotlin/at/aau/se2/skyjo/service/LobbyInviteServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/LobbyInviteServiceTest.kt
@@ -117,7 +117,20 @@ class LobbyInviteServiceTest {
             service.createInvite(user("user-a", "Alice"), lobby.lobbyId!!, toUserId = "user-b")
         }
 
-        assertTrue(error.message.orEmpty().contains("not waiting"))
+        assertTrue(error.message.orEmpty().contains("in progress"))
+    }
+
+    @Test
+    fun `failed one-player start leaves lobby invitable`() {
+        val lobby = lobbyService.createLobby(user("user-a", "Alice"))
+
+        assertThrows<IllegalStateException> {
+            lobbyService.startGame(userId = "user-a", lobbyId = lobby.lobbyId!!)
+        }
+        val invite = service.createInvite(user("user-a", "Alice"), lobby.lobbyId!!, toUserId = "user-b")
+
+        assertEquals(LobbyInviteStatus.PENDING, invite.status)
+        assertEquals("ABC123", invite.joinCode)
     }
 
     @Test
@@ -175,7 +188,29 @@ class LobbyInviteServiceTest {
             service.acceptInvite(user("user-b", "Bob"), invite.inviteId)
         }
 
-        assertTrue(error.message.orEmpty().contains("not waiting"))
+        assertTrue(error.message.orEmpty().contains("in progress"))
+    }
+
+    @Test
+    fun `createInvite rejects full lobbies`() {
+        val lobby = lobbyService.createLobby(user("user-a", "Alice"))
+        val additionalUsers = listOf(
+            user("user-c", "Cara"),
+            user("user-d", "Dan"),
+            user("user-e", "Eve"),
+            user("user-f", "Finn"),
+            user("user-g", "Gina"),
+        )
+        additionalUsers.drop(1).forEach { createUser(it.userId, it.username) }
+        additionalUsers.forEach { lobbyService.joinLobby(it, lobby.joinCode!!) }
+        createUser("user-h", "Hana")
+        friendRepository.createFriendship("user-a", "user-h", now = 1_000L)
+
+        val error = assertThrows<IllegalStateException> {
+            service.createInvite(user("user-a", "Alice"), lobby.lobbyId!!, toUserId = "user-h")
+        }
+
+        assertTrue(error.message.orEmpty().contains("full"))
     }
 
     @Test

--- a/src/test/kotlin/at/aau/se2/skyjo/service/MultiLobbyServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/MultiLobbyServiceTest.kt
@@ -62,6 +62,29 @@ class MultiLobbyServiceTest {
     }
 
     @Test
+    fun `new lobby is waiting and accepts join code joins`() {
+        val lobby = service.createLobby(user("user-1", "Alice"))
+
+        val joined = service.joinLobby(user("user-2", "Bob"), lobby.joinCode!!)
+
+        assertEquals(LobbyStatus.WAITING, joined.status)
+        assertEquals(listOf("Alice", "Bob"), joined.players.map { it.nickname })
+    }
+
+    @Test
+    fun `failed one-player start leaves lobby waiting and joinable`() {
+        val lobby = service.createLobby(user("user-1", "Alice"))
+
+        assertThrows<IllegalStateException> {
+            service.startGame(userId = "user-1", lobbyId = lobby.lobbyId!!)
+        }
+        val joined = service.joinLobby(user("user-2", "Bob"), lobby.joinCode!!)
+
+        assertEquals(LobbyStatus.WAITING, joined.status)
+        assertEquals(listOf("Alice", "Bob"), joined.players.map { it.nickname })
+    }
+
+    @Test
     fun `user cannot join two waiting lobbies`() {
         service.createLobby(user("user-1", "Alice"))
         service.createLobby(user("user-2", "Bob"))
@@ -148,6 +171,31 @@ class MultiLobbyServiceTest {
         }
 
         assertTrue(error.message.orEmpty().contains("not waiting"))
+    }
+
+    @Test
+    fun `joinLobby rejects lobbies after game start`() {
+        val lobby = service.createLobby(user("user-1", "Alice"))
+        service.joinLobby(user("user-2", "Bob"), lobby.joinCode!!)
+        service.startGame(userId = "user-1", lobbyId = lobby.lobbyId!!)
+
+        val error = assertThrows<IllegalStateException> {
+            service.joinLobby(user("user-3", "Cara"), lobby.joinCode!!)
+        }
+
+        assertTrue(error.message.orEmpty().contains("in progress"))
+    }
+
+    @Test
+    fun `joinLobby rejects closed lobbies`() {
+        val lobby = service.createLobby(user("user-1", "Alice"))
+        service.closeLobby(lobby.lobbyId!!)
+
+        val error = assertThrows<IllegalStateException> {
+            service.joinLobby(user("user-2", "Bob"), lobby.joinCode!!)
+        }
+
+        assertTrue(error.message.orEmpty().contains("closed"))
     }
 
     @Test

--- a/src/test/kotlin/at/aau/se2/skyjo/service/MultiLobbyServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/MultiLobbyServiceTest.kt
@@ -187,6 +187,19 @@ class MultiLobbyServiceTest {
     }
 
     @Test
+    fun `joinLobby lets existing members rejoin an in game lobby by code`() {
+        val lobby = service.createLobby(user("user-1", "Alice"))
+        service.joinLobby(user("user-2", "Bob"), lobby.joinCode!!)
+        service.startGame(userId = "user-1", lobbyId = lobby.lobbyId!!)
+
+        val rejoined = service.joinLobby(user("user-2", "Bob"), lobby.joinCode!!)
+
+        assertEquals(LobbyStatus.IN_GAME, rejoined.status)
+        assertEquals(lobby.lobbyId, rejoined.lobbyId)
+        assertEquals(listOf("Alice", "Bob"), rejoined.players.map { it.nickname })
+    }
+
+    @Test
     fun `joinLobby rejects closed lobbies`() {
         val lobby = service.createLobby(user("user-1", "Alice"))
         service.closeLobby(lobby.lobbyId!!)


### PR DESCRIPTION
## Why

Friends only showed as **online** while connected to a lobby/game websocket. A
friend sitting in the menus had no socket, so they appeared offline. This adds a
lightweight foreground heartbeat and makes online status TTL-based.

## What

- **`POST /api/social/heartbeat`** — authenticated endpoint that refreshes the
  caller's presence. Returns `204 No Content`.
- **`AuthRepository.touchPresence`** — upserts `connected = 1` + `updated_at`
  without clobbering `current_lobby_id` (so a heartbeat while in a lobby keeps
  the lobby association).
- **`FriendService.recordHeartbeat`** — delegates to the repository with the
  current time.
- **`FriendRepository.listFriends(userId, onlineSince)`** — a friend is now
  online only when `connected = 1 AND updated_at >= now - TTL` (TTL = 60s), so
  stale presence rows from crashed/backgrounded clients read as offline.

Pairs with the frontend PR that sends the heartbeat every ~20s while the app is
foregrounded.

## Tests

- `FriendRepositoryTest` — fresh vs. stale presence, `touchPresence` keeps lobby
  and marks online on first contact.
- `FriendServiceTest` — heartbeat marks online, no-presence is offline, online
  expires after the TTL.
- `FriendControllerTest` — heartbeat returns 204 and records presence; 401 for
  invalid token.

Full backend suite green (`./gradlew test`).