### PR TITLE
feat(persistence): restore full game state on restart, enable SQLite WAL

### DIFF
--- a/src/main/kotlin/at/aau/se2/skyjo/persistence/GameRepository.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/persistence/GameRepository.kt
@@ -3,6 +3,7 @@ package at.aau.se2.skyjo.persistence
 import at.aau.se2.skyjo.game.model.BoardPosition
 import at.aau.se2.skyjo.game.model.GamePhase
 import at.aau.se2.skyjo.game.model.GameState
+import at.aau.se2.skyjo.model.GameConfig
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.DeserializationFeature
@@ -17,10 +18,18 @@ import jakarta.annotation.PostConstruct
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Repository
 
+data class GameMeta(
+    val roundNumber: Int,
+    val totalScores: Map<String, Int>,
+    val config: GameConfig,
+    val playerInfo: Map<String, String>,
+)
+
 data class PersistedGame(
     val gameId: String,
     val lobbyId: String?,
     val state: GameState,
+    val meta: GameMeta? = null,
 )
 
 @Repository
@@ -55,12 +64,16 @@ class GameRepository(private val jdbc: JdbcTemplate) {
 
     @PostConstruct
     fun initSchema() {
+        // WAL improves durability and read/write concurrency for SQLite; it is a
+        // persistent database-level setting so running it once at startup is enough.
+        runCatching { jdbc.execute("PRAGMA journal_mode=WAL") }
         jdbc.execute(
             """
             CREATE TABLE IF NOT EXISTS games (
                 game_id TEXT PRIMARY KEY,
                 lobby_id TEXT,
                 state_json TEXT NOT NULL,
+                meta_json TEXT,
                 phase TEXT NOT NULL,
                 completed INTEGER NOT NULL DEFAULT 0,
                 updated_at INTEGER NOT NULL
@@ -69,6 +82,7 @@ class GameRepository(private val jdbc: JdbcTemplate) {
         )
         runCatching { jdbc.execute("ALTER TABLE games ADD COLUMN lobby_id TEXT") }
         runCatching { jdbc.execute("ALTER TABLE games ADD COLUMN completed INTEGER NOT NULL DEFAULT 0") }
+        runCatching { jdbc.execute("ALTER TABLE games ADD COLUMN meta_json TEXT") }
         jdbc.execute(
             """
             CREATE TABLE IF NOT EXISTS player_sessions (
@@ -85,20 +99,22 @@ class GameRepository(private val jdbc: JdbcTemplate) {
         saveGame(gameId, lobbyId = null, state = state, completed = completed)
     }
 
-    fun saveGame(gameId: String, lobbyId: String?, state: GameState, completed: Boolean = false) {
+    fun saveGame(gameId: String, lobbyId: String?, state: GameState, completed: Boolean = false, meta: GameMeta? = null) {
         val json = mapper.writeValueAsString(state)
+        val metaJson = meta?.let { mapper.writeValueAsString(it) }
         jdbc.update(
             """
-            INSERT INTO games (game_id, lobby_id, state_json, phase, completed, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT INTO games (game_id, lobby_id, state_json, meta_json, phase, completed, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(game_id) DO UPDATE SET
                 lobby_id = excluded.lobby_id,
                 state_json = excluded.state_json,
+                meta_json = excluded.meta_json,
                 phase = excluded.phase,
                 completed = excluded.completed,
                 updated_at = excluded.updated_at
             """.trimIndent(),
-            gameId, lobbyId, json, state.phase.name, if (completed) 1 else 0, System.currentTimeMillis()
+            gameId, lobbyId, json, metaJson, state.phase.name, if (completed) 1 else 0, System.currentTimeMillis()
         )
     }
 
@@ -108,12 +124,13 @@ class GameRepository(private val jdbc: JdbcTemplate) {
     fun loadActiveGames(): List<PersistedGame> {
         return try {
             jdbc.query(
-                "SELECT game_id, lobby_id, state_json FROM games WHERE completed = 0 AND phase != ? ORDER BY updated_at ASC",
+                "SELECT game_id, lobby_id, state_json, meta_json FROM games WHERE completed = 0 AND phase != ? ORDER BY updated_at ASC",
                 { rs, _ ->
                     PersistedGame(
                         gameId = rs.getString("game_id"),
                         lobbyId = rs.getString("lobby_id"),
                         state = mapper.readValue(rs.getString("state_json"), GameState::class.java),
+                        meta = rs.getString("meta_json")?.let { mapper.readValue(it, GameMeta::class.java) },
                     )
                 },
                 GamePhase.NOT_STARTED.name // WICHTIG: Hier darf nur noch DIESER EINE Parameter stehen!

--- a/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
+++ b/src/main/kotlin/at/aau/se2/skyjo/service/GameService.kt
@@ -34,6 +34,7 @@ import at.aau.se2.skyjo.model.PlayerScoreDto
 import at.aau.se2.skyjo.model.PlayActionCardMessageResult
 import at.aau.se2.skyjo.model.SlotType
 import at.aau.se2.skyjo.model.lobby.LobbyPlayer
+import at.aau.se2.skyjo.persistence.GameMeta
 import at.aau.se2.skyjo.persistence.GameRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
@@ -87,14 +88,15 @@ class GameService @Autowired constructor(
     init {
         gameRepository?.loadActiveGames()?.forEach { persisted ->
             val playerIds = persisted.state.players.map { it.id }
+            val meta = persisted.meta
             val managedGame = ManagedGame(
                 gameId = persisted.gameId,
                 lobbyId = persisted.lobbyId,
                 gameState = persisted.state,
-                config = GameConfig(),
-                roundNumber = 1,
-                totalScores = playerIds.associateWith { 0 },
-                playerInfo = playerIds.associateWith { it },
+                config = meta?.config ?: GameConfig(),
+                roundNumber = meta?.roundNumber ?: 1,
+                totalScores = meta?.totalScores ?: playerIds.associateWith { 0 },
+                playerInfo = meta?.playerInfo ?: playerIds.associateWith { it },
             )
             games[managedGame.gameId] = managedGame
             playerIds.forEach { playerGameIndex[it] = managedGame.gameId }
@@ -166,7 +168,7 @@ class GameService @Autowired constructor(
 
             game.gameState = newRoundState
             resetCheatReportRound(game, newRoundState.currentPlayerId)
-            gameRepository?.saveGame(game.gameId, game.lobbyId, newRoundState)
+            persist(game, newRoundState)
 
             // Frühzeitig zurückkehren, restliche Zug-Logik überspringen
             return@withLock toUpdateMessage(game, newRoundState, gameOver = false)
@@ -234,7 +236,7 @@ class GameService @Autowired constructor(
         if (action.completesTurn()) {
             advanceCheatReportTurn(game, updatedState.currentPlayerId)
         }
-        gameRepository?.saveGame(game.gameId, game.lobbyId, updatedState)
+        persist(game, updatedState)
 
         if (updatedState.phase == GamePhase.ROUND_FINISHED) {
             return@withLock handleRoundFinished(game, updatedState)
@@ -263,7 +265,7 @@ class GameService @Autowired constructor(
         if (!startedPendingAction) {
             advanceCheatReportTurn(game, updatedState.currentPlayerId)
         }
-        gameRepository?.saveGame(game.gameId, game.lobbyId, updatedState)
+        persist(game, updatedState)
 
         val update = if (updatedState.phase == GamePhase.ROUND_FINISHED) {
             handleRoundFinished(game, updatedState)
@@ -300,7 +302,7 @@ class GameService @Autowired constructor(
         game.cheatPeekCounts[resolvedPlayerId] = updatedUsedPeeks
         game.playerCheatedThisTurn = true
         game.gameState = peekResult.state
-        gameRepository?.saveGame(game.gameId, game.lobbyId, peekResult.state)
+        persist(game, peekResult.state)
 
         CheatPeekResultMessage(
             card = toCardDto(peekResult.card),
@@ -441,7 +443,7 @@ class GameService @Autowired constructor(
 
         games[managedGame.gameId] = managedGame
         currentGameId = managedGame.gameId
-        gameRepository?.saveGame(managedGame.gameId, managedGame.lobbyId, newState)
+        persist(managedGame, newState)
         return toUpdateMessage(managedGame, newState, gameOver = false)
     }
 
@@ -461,7 +463,7 @@ class GameService @Autowired constructor(
 
         if (isGameOver) {
             game.completed = true
-            gameRepository?.saveGame(game.gameId, game.lobbyId, finishedState, completed = true)
+            persist(game, finishedState, completed = true)
             gameRepository?.deletePlayerSessionsForGame(game.gameId)
             game.lobbyId?.let { lobbyService?.closeLobby(it) }
             removePlayerIndexes(game)
@@ -469,7 +471,7 @@ class GameService @Autowired constructor(
             return toUpdateMessage(game, finishedState, gameOver = true)
         }
         //"Handbremse" zum anzeigen der Rundenergebnisse
-        gameRepository?.saveGame(game.gameId, game.lobbyId, finishedState)
+        persist(game, finishedState)
         return toUpdateMessage(game, finishedState, gameOver = false)
     }
 
@@ -540,6 +542,21 @@ class GameService @Autowired constructor(
         if (recordedStatsGameIds.add(game.gameId)) {
             statsService?.recordGameResult(game.gameId, game.totalScores)
         }
+    }
+
+    private fun persist(game: ManagedGame, state: GameState, completed: Boolean = false) {
+        gameRepository?.saveGame(
+            gameId = game.gameId,
+            lobbyId = game.lobbyId,
+            state = state,
+            completed = completed,
+            meta = GameMeta(
+                roundNumber = game.roundNumber,
+                totalScores = game.totalScores,
+                config = game.config,
+                playerInfo = game.playerInfo,
+            ),
+        )
     }
 
     private fun removePlayerIndexes(game: ManagedGame) {

--- a/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
+++ b/src/test/kotlin/at/aau/se2/skyjo/service/GameServiceTest.kt
@@ -1271,6 +1271,31 @@ class GameServiceTest {
     }
 
     @Test
+    fun `round number and scores are restored after a restart`() {
+        val dataSource = SingleConnectionDataSource("jdbc:sqlite::memory:", true)
+        val jdbc = JdbcTemplate(dataSource)
+        val repository = GameRepository(jdbc)
+        repository.initSchema()
+        service = GameService(engine, repository)
+        service.startGame(players, GameConfig(maxRounds = 5, targetScore = 1000))
+
+        // Finish round 1 (accumulates scores) without ending the game, then start round 2.
+        val roundOne = getInternalGameState(service)
+        val finished = engine.finishRound(roundOne.copy(finisherPlayerId = roundOne.currentPlayerId!!))
+        val afterRound = service.handleRoundFinished(finished)
+        assertFalse(afterRound.gameOver)
+        val nextRound = service.processAction(player1Id, GameActionMessage(ActionType.START_NEXT_ROUND))
+        assertEquals(2, nextRound.roundNumber)
+        val expectedScores = nextRound.totalScores.associate { it.playerId to it.totalScore }
+
+        // Simulate a server restart: a fresh GameService over the same repository.
+        val restored = GameService(engine, repository).getCurrentState(player1Id)!!
+
+        assertEquals(2, restored.roundNumber)
+        assertEquals(expectedScores, restored.totalScores.associate { it.playerId to it.totalScore })
+    }
+
+    @Test
     fun `completed lobby game works when no lobby service is configured`() {
         service = GameService(engine, null)
         service.startGame("lobby-1", players, GameConfig(maxRounds = 1))


### PR DESCRIPTION
> **Stacked on #44 + #46.** Base on / merge after those. The diff against #46's
> branch is PR-5 only.

## What & why

On restart, `GameService.init` reloaded active games from SQLite but rebuilt them
with **default metadata** — `roundNumber = 1`, `totalScores = 0`, default
`GameConfig`, and `playerInfo = id -> id`. Only the raw `GameState` was persisted,
so a server restart mid-match silently wiped round progress, running scores, the
configured round/target limits, and player nicknames.

This persists that metadata alongside the game state and restores it.

Also enables **SQLite WAL** for better durability and read/write concurrency.

## Changes

- `GameRepository`: new `GameMeta(roundNumber, totalScores, config, playerInfo)`
  stored as `meta_json` (new nullable column, added via `ALTER TABLE` migration).
  `saveGame` takes an optional `meta`; `loadActiveGames` reads it back
  (`PersistedGame.meta`, null for legacy rows).
- `GameService`: all seven `saveGame` sites now go through one `persist(game, state)`
  helper that includes the metadata; `init` restores `roundNumber`/`totalScores`/
  `config`/`playerInfo` from `meta` (falling back to the old defaults when absent).
- `PRAGMA journal_mode=WAL` set once at startup in `GameRepository.initSchema`.

## Testing

Full suite green. Added a test that finishes a round, advances to round 2, then
rebuilds `GameService` over the same repository (simulating a restart) and asserts
the restored game keeps its round number and running scores. Existing persistence
tests unchanged (legacy rows with null `meta` still load with prior defaults).

## Not included

Per-entity locks (replacing the per-service global `ReentrantLock`) were left out:
they touch both `GameService` and `LobbyService`, so they'd stack on #44 **and**
#45, and they're a concurrency/perf optimization rather than a correctness fix.
Best done once this stack and #45 land.

## Context

Stage 5 (persistence robustness) of the dual-model consolidation.
